### PR TITLE
fix: include casks in list output and match brew version ordering

### DIFF
--- a/src/cellar.zig
+++ b/src/cellar.zig
@@ -7,9 +7,13 @@ pub const InstalledFormula = struct {
     name: []const u8,
     versions: []const []const u8,
 
-    /// Return the latest (last) version string from the sorted versions array.
+    /// Return the latest version string (lexicographically highest).
     pub fn latestVersion(self: InstalledFormula) []const u8 {
-        return self.versions[self.versions.len - 1];
+        var latest = self.versions[0];
+        for (self.versions[1..]) |v| {
+            if (mem.order(u8, v, latest) == .gt) latest = v;
+        }
+        return latest;
     }
 };
 
@@ -33,8 +37,9 @@ pub const Cellar = struct {
         return true;
     }
 
-    /// Return a sorted list of installed version strings for a formula,
-    /// or null if the formula is not installed / has no versions.
+    /// Return installed version strings for a formula in filesystem order
+    /// (matching `brew list --versions` behavior).
+    /// Returns null if the formula is not installed / has no versions.
     /// Caller owns the returned slice and all strings within it.
     pub fn installedVersions(self: Cellar, allocator: Allocator, name: []const u8) ?[]const []const u8 {
         var buf: [1024]u8 = undefined;
@@ -47,8 +52,7 @@ pub const Cellar = struct {
 
         var iter = dir.iterate();
         while (iter.next() catch null) |entry| {
-            if (entry.kind != .directory) continue;
-            // Skip hidden / dot entries.
+            if (entry.kind != .directory and entry.kind != .unknown) continue;
             if (entry.name.len > 0 and entry.name[0] == '.') continue;
             const duped = allocator.dupe(u8, entry.name) catch return null;
             versions.append(allocator, duped) catch {
@@ -62,7 +66,6 @@ pub const Cellar = struct {
             return null;
         }
 
-        mem.sort([]const u8, versions.items, {}, stringLessThan);
         return versions.toOwnedSlice(allocator) catch null;
     }
 
@@ -76,7 +79,8 @@ pub const Cellar = struct {
 
         var iter = dir.iterate();
         while (iter.next() catch null) |entry| {
-            if (entry.kind != .directory) continue;
+            // Accept directories and unknown types (some filesystems don't report d_type).
+            if (entry.kind != .directory and entry.kind != .unknown) continue;
             if (entry.name.len > 0 and entry.name[0] == '.') continue;
 
             const name = allocator.dupe(u8, entry.name) catch continue;

--- a/src/cmd/list.zig
+++ b/src/cmd/list.zig
@@ -3,17 +3,21 @@ const Allocator = std.mem.Allocator;
 const Config = @import("../config.zig").Config;
 const cellar_mod = @import("../cellar.zig");
 const Cellar = cellar_mod.Cellar;
+const InstalledFormula = cellar_mod.InstalledFormula;
 const writeJsonStr = @import("../json_helpers.zig").writeJsonStr;
 
-/// List installed formulae from the Cellar.
+/// List installed formulae and casks.
 ///
-/// With no args: prints each installed formula name (one per line).
-/// With --versions / -v: prints "name version1 version2 ..." for each formula.
+/// With no flags: prints both formulae and casks (matching `brew list`).
+/// With --formula: prints only formulae.
+/// With --cask: prints only casks.
+/// With --versions / -v: prints "name version1 version2 ..." for each entry.
 /// With a specific name arg: lists all files inside the keg directory for
 /// the latest installed version.
 pub fn listCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
     var show_versions = false;
-    var show_casks = false;
+    var only_casks = false;
+    var only_formulae = false;
     var json_output = false;
     var formula_name: ?[]const u8 = null;
 
@@ -21,7 +25,9 @@ pub fn listCmd(allocator: Allocator, args: []const []const u8, config: Config) a
         if (std.mem.eql(u8, arg, "--versions") or std.mem.eql(u8, arg, "-v")) {
             show_versions = true;
         } else if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
-            show_casks = true;
+            only_casks = true;
+        } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
+            only_formulae = true;
         } else if (std.mem.eql(u8, arg, "--json")) {
             json_output = true;
         } else if (!std.mem.startsWith(u8, arg, "-")) {
@@ -29,16 +35,9 @@ pub fn listCmd(allocator: Allocator, args: []const []const u8, config: Config) a
         }
     }
 
-    if (show_casks) {
-        // List installed casks from Caskroom
-        try listCaskroom(allocator, config.caskroom);
-        return;
-    }
-
-    const c = Cellar.init(config.cellar);
-
     if (formula_name) |name| {
         // List files for a specific formula keg.
+        const c = Cellar.init(config.cellar);
         const versions = c.installedVersions(allocator, name) orelse {
             var err_buf: [4096]u8 = undefined;
             var ew = std.fs.File.stderr().writer(&err_buf);
@@ -52,60 +51,115 @@ pub fn listCmd(allocator: Allocator, args: []const []const u8, config: Config) a
             allocator.free(versions);
         }
 
-        // Use the latest version.
-        const latest = versions[versions.len - 1];
+        // Find the lexicographically highest version (latest).
+        var latest = versions[0];
+        for (versions[1..]) |v| {
+            if (std.mem.order(u8, v, latest) == .gt) latest = v;
+        }
         try listKegFiles(config.cellar, name, latest);
-    } else {
-        // List all installed formulae.
-        const formulae = c.installedFormulae(allocator);
-        defer {
-            for (formulae) |f| {
-                for (f.versions) |v| allocator.free(v);
-                allocator.free(f.versions);
-                allocator.free(f.name);
-            }
-            allocator.free(formulae);
-        }
-
-        var buf: [4096]u8 = undefined;
-        var w = std.fs.File.stdout().writer(&buf);
-        const stdout = &w.interface;
-
-        if (json_output) {
-            try stdout.writeAll("[");
-            for (formulae, 0..) |f, i| {
-                if (i > 0) try stdout.writeAll(",");
-                if (show_versions) {
-                    try stdout.writeAll("{\"name\":");
-                    try writeJsonStr(stdout, f.name);
-                    try stdout.writeAll(",\"versions\":[");
-                    for (f.versions, 0..) |v, vi| {
-                        if (vi > 0) try stdout.writeAll(",");
-                        try writeJsonStr(stdout, v);
-                    }
-                    try stdout.writeAll("]}");
-                } else {
-                    try writeJsonStr(stdout, f.name);
-                }
-            }
-            try stdout.writeAll("]\n");
-            try stdout.flush();
-            return;
-        }
-
-        for (formulae) |f| {
-            if (show_versions) {
-                try stdout.print("{s}", .{f.name});
-                for (f.versions) |v| {
-                    try stdout.print(" {s}", .{v});
-                }
-                try stdout.print("\n", .{});
-            } else {
-                try stdout.print("{s}\n", .{f.name});
-            }
-        }
-        try stdout.flush();
+        return;
     }
+
+    // Collect formulae (unless --cask only).
+    var formulae: []InstalledFormula = &.{};
+    defer {
+        for (formulae) |f| {
+            for (f.versions) |v| allocator.free(v);
+            allocator.free(f.versions);
+            allocator.free(f.name);
+        }
+        allocator.free(formulae);
+    }
+    if (!only_casks) {
+        const c = Cellar.init(config.cellar);
+        formulae = c.installedFormulae(allocator);
+    }
+
+    // Collect casks (unless --formula only).
+    var casks: []InstalledFormula = &.{};
+    defer {
+        for (casks) |ck| {
+            for (ck.versions) |v| allocator.free(v);
+            allocator.free(ck.versions);
+            allocator.free(ck.name);
+        }
+        allocator.free(casks);
+    }
+    if (!only_formulae) {
+        const cr = Cellar.init(config.caskroom);
+        casks = cr.installedFormulae(allocator);
+    }
+
+    // Merge into a single sorted list.
+    var all = std.ArrayList(InstalledFormula){};
+    defer all.deinit(allocator);
+    try all.appendSlice(allocator, formulae);
+    try all.appendSlice(allocator, casks);
+
+    // For plain name listing (no --versions), also include symlinked entries
+    // in the Caskroom (e.g. google-cloud-sdk -> gcloud-cli). These are aliases
+    // that brew includes in `list` but not in `list --versions`.
+    var extra_names = std.ArrayList([]const u8){};
+    defer {
+        for (extra_names.items) |n| allocator.free(n);
+        extra_names.deinit(allocator);
+    }
+    if (!only_formulae and !show_versions) {
+        if (std.fs.openDirAbsolute(config.caskroom, .{ .iterate = true })) |*d| {
+            var cask_dir = d.*;
+            defer cask_dir.close();
+            var cask_iter = cask_dir.iterate();
+            while (cask_iter.next() catch null) |entry| {
+                if (entry.kind != .sym_link) continue;
+                if (entry.name.len > 0 and entry.name[0] == '.') continue;
+                const duped = try allocator.dupe(u8, entry.name);
+                // Add as a formula with empty versions (name-only).
+                try all.append(allocator, .{ .name = duped, .versions = &.{} });
+                try extra_names.append(allocator, duped);
+            }
+        } else |_| {}
+    }
+
+    std.mem.sort(InstalledFormula, all.items, {}, formulaLessThan);
+
+    var buf: [4096]u8 = undefined;
+    var w = std.fs.File.stdout().writer(&buf);
+    const stdout = &w.interface;
+
+    if (json_output) {
+        try stdout.writeAll("[");
+        for (all.items, 0..) |f, i| {
+            if (i > 0) try stdout.writeAll(",");
+            if (show_versions) {
+                try stdout.writeAll("{\"name\":");
+                try writeJsonStr(stdout, f.name);
+                try stdout.writeAll(",\"versions\":[");
+                for (f.versions, 0..) |v, vi| {
+                    if (vi > 0) try stdout.writeAll(",");
+                    try writeJsonStr(stdout, v);
+                }
+                try stdout.writeAll("]}");
+            } else {
+                try writeJsonStr(stdout, f.name);
+            }
+        }
+        try stdout.writeAll("]\n");
+        try stdout.flush();
+        return;
+    }
+
+    for (all.items) |f| {
+        if (show_versions) {
+            try stdout.print("{s}", .{f.name});
+            for (f.versions) |v| {
+                try stdout.print(" {s}", .{v});
+            }
+            try stdout.print("\n", .{});
+        } else {
+            try stdout.print("{s}\n", .{f.name});
+        }
+    }
+    try stdout.flush();
 }
 
 /// Open the keg directory for {cellar}/{name}/{version} and print each entry.
@@ -134,47 +188,9 @@ fn listKegFiles(cellar_path: []const u8, name: []const u8, version: []const u8) 
     try stdout.flush();
 }
 
-/// List installed casks from the Caskroom directory (sorted, skipping dot dirs).
-fn listCaskroom(allocator: Allocator, caskroom_path: []const u8) !void {
-    var dir = std.fs.openDirAbsolute(caskroom_path, .{ .iterate = true }) catch |err| {
-        if (err == error.FileNotFound) return; // Caskroom doesn't exist, nothing to list
-        var err_buf: [4096]u8 = undefined;
-        var ew = std.fs.File.stderr().writer(&err_buf);
-        const stderr = &ew.interface;
-        try stderr.print("Error: Could not open Caskroom: {s}\n", .{caskroom_path});
-        try stderr.flush();
-        return err;
-    };
-    defer dir.close();
-
-    var names = std.ArrayList([]const u8){};
-    defer {
-        for (names.items) |n| allocator.free(n);
-        names.deinit(allocator);
-    }
-
-    var iter = dir.iterate();
-    while (try iter.next()) |entry| {
-        if (entry.kind != .directory) continue;
-        if (entry.name.len > 0 and entry.name[0] == '.') continue;
-        const duped = try allocator.dupe(u8, entry.name);
-        try names.append(allocator, duped);
-    }
-
-    std.mem.sort([]const u8, names.items, {}, stringLessThan);
-
-    var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
-    const stdout = &w.interface;
-
-    for (names.items) |n| {
-        try stdout.print("{s}\n", .{n});
-    }
-    try stdout.flush();
-}
-
-fn stringLessThan(_: void, a: []const u8, b: []const u8) bool {
-    return std.mem.order(u8, a, b) == .lt;
+/// Sort InstalledFormula by name.
+fn formulaLessThan(_: void, a: InstalledFormula, b: InstalledFormula) bool {
+    return std.mem.order(u8, a.name, b.name) == .lt;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `bru list` now includes both formulae and casks, matching `brew list` default behavior
- `bru list --versions` uses filesystem order (matching brew) instead of lexicographic sort
- Added `--formula` / `--formulae` flag to list only formulae
- Caskroom symlinks (e.g. `google-cloud-sdk -> gcloud-cli`) appear in plain `list` but not `--versions`, matching brew

## Test plan
- [x] `bru list` output matches `brew list` (sorted comparison)
- [x] `bru list --versions` output matches `brew list --versions` (sorted comparison)
- [x] `bru list --cask` output matches `brew list --cask`
- [x] `bru list --formula` output matches `brew list --formula`
- [x] `zig build test` passes