### PR TITLE
fix: leaves command missing tap prefixes and some entries

### DIFF
--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -186,6 +186,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
         .runtime_dependencies = runtime_deps.items,
         .compiler = "clang",
         .homebrew_version = "bru 0.1.0",
+        .source_tap = "homebrew/core",
     };
     try tab.writeToKeg(allocator, keg_path);
 

--- a/src/cmd/leaves.zig
+++ b/src/cmd/leaves.zig
@@ -1,29 +1,23 @@
 const std = @import("std");
-const Allocator = std.mem.Allocator;
+const mem = std.mem;
+const Allocator = mem.Allocator;
 const Config = @import("../config.zig").Config;
 const Cellar = @import("../cellar.zig").Cellar;
-const Index = @import("../index.zig").Index;
 const Tab = @import("../tab.zig").Tab;
 const writeJsonStr = @import("../json_helpers.zig").writeJsonStr;
 
 /// Show installed formulae that are not dependencies of any other installed formula.
 ///
-/// For each installed formula, if it is NOT in the set of dependencies of any
-/// other installed formula and was installed on request, its name is printed.
+/// For each installed formula, if it is NOT in the set of runtime dependencies
+/// of any other installed formula, its name is printed (with tap prefix for
+/// non-homebrew/core taps). Supports --json for JSON array output.
 pub fn leavesCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
     var json_output = false;
     for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
+        if (mem.eql(u8, arg, "--json")) {
             json_output = true;
         }
     }
-
-    // Load the formula index from disk or build from the JWS cache.
-    var index = try Index.loadOrBuild(allocator, config.cache);
-    // Note: do not call index.deinit() -- the index may be mmap'd (from disk)
-    // in which case the allocator field is undefined. The process exits after
-    // this command so OS reclamation is sufficient.
-    _ = &index;
 
     // Get all installed formulae from the cellar.
     const cellar = Cellar.init(config.cellar);
@@ -37,21 +31,60 @@ pub fn leavesCmd(allocator: Allocator, args: []const []const u8, config: Config)
         allocator.free(installed);
     }
 
-    // Build a set of all dependency names across every installed formula.
+    // Build a set of all dependency names by reading each formula's
+    // INSTALL_RECEIPT.json runtime_dependencies. This is more accurate than the
+    // index because it reflects the actual installed dependency graph and works
+    // for formulae from any tap, not just homebrew/core.
+    //
+    // We also cache each formula's source_tap from its Tab so we don't have to
+    // re-read the receipt in the display loop.
     var dep_set = std.StringHashMap(void).init(allocator);
-    defer dep_set.deinit();
+    defer {
+        var it = dep_set.keyIterator();
+        while (it.next()) |key| allocator.free(key.*);
+        dep_set.deinit();
+    }
+
+    var tap_map = std.StringHashMap([]const u8).init(allocator);
+    defer {
+        var it = tap_map.valueIterator();
+        while (it.next()) |val| allocator.free(val.*);
+        tap_map.deinit();
+    }
 
     for (installed) |formula| {
-        const entry = index.lookup(formula.name) orelse continue;
-        const deps = index.getStringList(allocator, entry.deps_offset) catch continue;
-        defer allocator.free(deps);
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const keg_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}", .{
+            config.cellar,
+            formula.name,
+            formula.latestVersion(),
+        }) catch continue;
 
-        for (deps) |dep| {
-            dep_set.put(dep, {}) catch {};
+        const tab = Tab.loadFromKeg(allocator, keg_path) orelse continue;
+        defer tab.deinit(allocator);
+
+        for (tab.runtime_dependencies) |dep| {
+            if (!dep_set.contains(dep.full_name)) {
+                const duped = allocator.dupe(u8, dep.full_name) catch continue;
+                dep_set.put(duped, {}) catch {
+                    allocator.free(duped);
+                    continue;
+                };
+            }
+        }
+
+        // Cache source_tap for the display loop.
+        if (tab.source_tap.len > 0 and !mem.eql(u8, tab.source_tap, "homebrew/core")) {
+            const duped_tap = allocator.dupe(u8, tab.source_tap) catch continue;
+            tap_map.put(formula.name, duped_tap) catch {
+                allocator.free(duped_tap);
+                continue;
+            };
         }
     }
 
-    // Print each installed formula that is not a dependency and was installed on request.
+    // Print each installed formula that is not a dependency of another formula.
+    // Use tap-prefixed names for formulae from non-homebrew/core taps.
     var buf: [4096]u8 = undefined;
     var w = std.fs.File.stdout().writer(&buf);
     const stdout = &w.interface;
@@ -62,22 +95,15 @@ pub fn leavesCmd(allocator: Allocator, args: []const []const u8, config: Config)
         for (installed) |formula| {
             if (dep_set.contains(formula.name)) continue;
 
-            var path_buf: [1024]u8 = undefined;
-            const keg_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}", .{
-                config.cellar,
-                formula.name,
-                formula.latestVersion(),
-            }) catch continue;
-
-            const tab = Tab.loadFromKeg(allocator, keg_path) orelse continue;
-            defer tab.deinit(allocator);
-
-            if (tab.installed_on_request) {
-                const display_name = getDisplayName(&index, formula.name);
-                if (!first) try stdout.writeAll(",");
+            if (!first) try stdout.writeAll(",");
+            if (tap_map.get(formula.name)) |tap| {
+                var name_buf: [1024]u8 = undefined;
+                const display_name = std.fmt.bufPrint(&name_buf, "{s}/{s}", .{ tap, formula.name }) catch continue;
                 try writeJsonStr(stdout, display_name);
-                first = false;
+            } else {
+                try writeJsonStr(stdout, formula.name);
             }
+            first = false;
         }
         try stdout.writeAll("]\n");
         try stdout.flush();
@@ -87,34 +113,14 @@ pub fn leavesCmd(allocator: Allocator, args: []const []const u8, config: Config)
     for (installed) |formula| {
         if (dep_set.contains(formula.name)) continue;
 
-        // Build the keg path for the latest version to read the Tab.
-        var path_buf: [1024]u8 = undefined;
-        const keg_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}", .{
-            config.cellar,
-            formula.name,
-            formula.latestVersion(),
-        }) catch continue;
-
-        const tab = Tab.loadFromKeg(allocator, keg_path) orelse continue;
-        defer tab.deinit(allocator);
-
-        if (tab.installed_on_request) {
-            const display_name = getDisplayName(&index, formula.name);
-            try stdout.print("{s}\n", .{display_name});
+        if (tap_map.get(formula.name)) |tap| {
+            try stdout.print("{s}/{s}\n", .{ tap, formula.name });
+        } else {
+            try stdout.print("{s}\n", .{formula.name});
         }
     }
 
     try stdout.flush();
-}
-
-/// Resolve display name: use full_name from index if it's a non-core tap, otherwise short name.
-fn getDisplayName(index: *const Index, name: []const u8) []const u8 {
-    const entry = index.lookup(name) orelse return name;
-    const full = index.getString(entry.full_name_offset);
-    if (full.len > 0 and !std.mem.startsWith(u8, full, "homebrew/core/")) {
-        return full;
-    }
-    return name;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tab.zig
+++ b/src/tab.zig
@@ -20,6 +20,7 @@ pub const Tab = struct {
     runtime_dependencies: []const RuntimeDep,
     compiler: []const u8,
     homebrew_version: []const u8,
+    source_tap: []const u8,
 
     /// Attempt to load and parse a Tab from a keg directory.
     /// Expects {keg_path}/INSTALL_RECEIPT.json to exist.
@@ -53,10 +54,33 @@ pub const Tab = struct {
             return null;
         };
 
+        // Parse source.tap.
+        const source_tap = blk: {
+            const source_val = root.get("source") orelse break :blk allocator.dupe(u8, "") catch {
+                allocator.free(compiler);
+                allocator.free(homebrew_version);
+                return null;
+            };
+            const source_obj = switch (source_val) {
+                .object => |o| o,
+                else => break :blk allocator.dupe(u8, "") catch {
+                    allocator.free(compiler);
+                    allocator.free(homebrew_version);
+                    return null;
+                },
+            };
+            break :blk allocator.dupe(u8, jsonStr(source_obj, "tap") orelse "") catch {
+                allocator.free(compiler);
+                allocator.free(homebrew_version);
+                return null;
+            };
+        };
+
         // Parse runtime_dependencies array.
         const deps = parseRuntimeDeps(allocator, root) catch {
             allocator.free(compiler);
             allocator.free(homebrew_version);
+            allocator.free(source_tap);
             return null;
         };
 
@@ -68,6 +92,7 @@ pub const Tab = struct {
             .runtime_dependencies = deps,
             .compiler = compiler,
             .homebrew_version = homebrew_version,
+            .source_tap = source_tap,
         };
     }
 
@@ -81,6 +106,7 @@ pub const Tab = struct {
         allocator.free(self.runtime_dependencies);
         allocator.free(self.compiler);
         allocator.free(self.homebrew_version);
+        allocator.free(self.source_tap);
     }
 
     /// Write an INSTALL_RECEIPT.json file into the keg directory.
@@ -134,7 +160,11 @@ pub const Tab = struct {
         }
         try writer.writeAll("],\n");
 
-        try writer.writeAll("  \"source\": {\"spec\": \"stable\"}\n");
+        if (self.source_tap.len > 0) {
+            try writer.print("  \"source\": {{\"spec\": \"stable\", \"tap\": \"{s}\"}}\n", .{self.source_tap});
+        } else {
+            try writer.writeAll("  \"source\": {\"spec\": \"stable\"}\n");
+        }
         try writer.writeAll("}\n");
 
         const file = try std.fs.createFileAbsolute(receipt_path, .{});
@@ -301,6 +331,7 @@ test "Tab writeToKeg round-trips" {
         .runtime_dependencies = &.{},
         .compiler = "clang",
         .homebrew_version = "bru 0.1.0",
+        .source_tap = "",
     };
     try tab.writeToKeg(allocator, tmp_path);
 
@@ -338,6 +369,7 @@ test "Tab writeToKeg round-trips with runtime_dependencies" {
         .runtime_dependencies = deps,
         .compiler = "clang",
         .homebrew_version = "bru 0.1.0",
+        .source_tap = "",
     };
     try tab.writeToKeg(allocator, tmp_path);
 
@@ -372,6 +404,7 @@ test "Tab writeToKeg escapes special characters" {
         .runtime_dependencies = &.{},
         .compiler = "clang",
         .homebrew_version = "bru \"test\" 0.1.0",
+        .source_tap = "",
     };
     try tab.writeToKeg(allocator, tmp_path);
 


### PR DESCRIPTION
## Summary
- Remove incorrect `installed_on_request` filter — `brew leaves` only checks whether a formula is a dependency of another installed formula, not how it was installed
- Switch dependency graph source from homebrew/core index to `runtime_dependencies` in each formula's `INSTALL_RECEIPT.json`, which works for all taps
- Parse `source.tap` from `INSTALL_RECEIPT.json` and display tap-prefixed names for non-homebrew/core formulae (e.g. `moderneinc/moderne/mod`)
- Fix use-after-free: dupe dependency names into dep_set so they outlive the Tab that owns them

Closes #7

## Test plan
- [x] `zig build test` passes
- [x] `bru leaves` output identical to `brew leaves` (33 entries, exact match)
- [x] `moderneinc/moderne/mod` displays with tap prefix
- [x] Previously missing entries (`icu4c@76`, `icu4c@77`, `liblqr`, `libraw`, `lld@19`, `python@3.12`) now appear
- [x] `--json` output preserved from upstream