### PR TITLE
feat: add per-command flag completions for bash, zsh, and fish

### DIFF
--- a/completions/bru.bash
+++ b/completions/bru.bash
@@ -7,14 +7,50 @@ _bru() {
     commands="install uninstall upgrade update search info list deps uses leaves
               autoremove link unlink cleanup outdated fetch config"
 
+    # Position 1: complete commands or global flags
     if [[ ${COMP_CWORD} -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
+        if [[ "${cur}" == -* ]]; then
+            COMPREPLY=( $(compgen -W "--help --version --verbose --quiet --debug" -- "${cur}") )
+        else
+            COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
+        fi
         return 0
     fi
 
-    case "${prev}" in
+    # Find the subcommand (first non-flag argument after bru)
+    local subcmd=""
+    local i
+    for (( i=1; i < COMP_CWORD; i++ )); do
+        case "${COMP_WORDS[i]}" in
+            -*) ;;
+            *) subcmd="${COMP_WORDS[i]}"; break ;;
+        esac
+    done
+
+    # Per-command flag completion when current word starts with -
+    if [[ "${cur}" == -* && -n "${subcmd}" ]]; then
+        local flags=""
+        case "${subcmd}" in
+            deps)       flags="--tree --1 --direct --include-build --json" ;;
+            uses)       flags="--installed --include-build" ;;
+            list)       flags="--versions --cask --casks --json" ;;
+            info)       flags="--json" ;;
+            search)     flags="--json" ;;
+            leaves)     flags="--json" ;;
+            outdated)   flags="--verbose --json" ;;
+            link)       flags="--force" ;;
+            cleanup)    flags="--dry-run -n --prune=" ;;
+            autoremove) flags="--dry-run -n" ;;
+        esac
+        if [[ -n "${flags}" ]]; then
+            COMPREPLY=( $(compgen -W "${flags}" -- "${cur}") )
+            return 0
+        fi
+    fi
+
+    # Formula name completion for commands that accept formulae
+    case "${subcmd}" in
         install|info|deps|uses|uninstall|link|unlink|upgrade|fetch)
-            # Complete with formula names
             local formulae
             formulae=$(bru search "${cur}" 2>/dev/null)
             COMPREPLY=( $(compgen -W "${formulae}" -- "${cur}") )

--- a/completions/bru.fish
+++ b/completions/bru.fish
@@ -1,4 +1,6 @@
 # Fish completion for bru
+
+# Subcommands
 complete -c bru -n '__fish_use_subcommand' -a install -d 'Install a formula'
 complete -c bru -n '__fish_use_subcommand' -a uninstall -d 'Uninstall a formula'
 complete -c bru -n '__fish_use_subcommand' -a upgrade -d 'Upgrade outdated formulae'
@@ -16,3 +18,52 @@ complete -c bru -n '__fish_use_subcommand' -a cleanup -d 'Remove old versions'
 complete -c bru -n '__fish_use_subcommand' -a outdated -d 'Show outdated'
 complete -c bru -n '__fish_use_subcommand' -a fetch -d 'Download only'
 complete -c bru -n '__fish_use_subcommand' -a config -d 'Show config'
+
+# Global flags
+complete -c bru -n '__fish_use_subcommand' -l help -d 'Show help'
+complete -c bru -n '__fish_use_subcommand' -l version -d 'Show version'
+complete -c bru -n '__fish_use_subcommand' -l verbose -d 'Verbose output'
+complete -c bru -n '__fish_use_subcommand' -l quiet -d 'Quiet output'
+complete -c bru -n '__fish_use_subcommand' -l debug -d 'Debug output'
+
+# deps flags
+complete -c bru -n '__fish_seen_subcommand_from deps' -l tree -d 'Show as indented tree'
+complete -c bru -n '__fish_seen_subcommand_from deps' -l 1 -d 'Show only direct dependencies'
+complete -c bru -n '__fish_seen_subcommand_from deps' -l direct -d 'Show only direct dependencies'
+complete -c bru -n '__fish_seen_subcommand_from deps' -l include-build -d 'Include build-time dependencies'
+complete -c bru -n '__fish_seen_subcommand_from deps' -l json -d 'Output as JSON'
+
+# uses flags
+complete -c bru -n '__fish_seen_subcommand_from uses' -l installed -d 'Only show installed formulae'
+complete -c bru -n '__fish_seen_subcommand_from uses' -l include-build -d 'Include build-time dependency relationships'
+
+# list flags
+complete -c bru -n '__fish_seen_subcommand_from list' -l versions -d 'Show version numbers'
+complete -c bru -n '__fish_seen_subcommand_from list' -l cask -d 'Only casks'
+complete -c bru -n '__fish_seen_subcommand_from list' -l casks -d 'Only casks'
+complete -c bru -n '__fish_seen_subcommand_from list' -l json -d 'Output as JSON'
+
+# info flags
+complete -c bru -n '__fish_seen_subcommand_from info' -l json -d 'Output as JSON'
+
+# search flags
+complete -c bru -n '__fish_seen_subcommand_from search' -l json -d 'Output as JSON'
+
+# leaves flags
+complete -c bru -n '__fish_seen_subcommand_from leaves' -l json -d 'Output as JSON'
+
+# outdated flags
+complete -c bru -n '__fish_seen_subcommand_from outdated' -l verbose -d 'Show version comparison'
+complete -c bru -n '__fish_seen_subcommand_from outdated' -l json -d 'Output as JSON'
+
+# link flags
+complete -c bru -n '__fish_seen_subcommand_from link' -l force -d 'Force linking of keg-only formulae'
+
+# cleanup flags
+complete -c bru -n '__fish_seen_subcommand_from cleanup' -l dry-run -d 'Show what would be removed'
+complete -c bru -n '__fish_seen_subcommand_from cleanup' -s n -d 'Show what would be removed'
+complete -c bru -n '__fish_seen_subcommand_from cleanup' -l prune -d 'Override default retention (days)' -r
+
+# autoremove flags
+complete -c bru -n '__fish_seen_subcommand_from autoremove' -l dry-run -d 'Show what would be removed'
+complete -c bru -n '__fish_seen_subcommand_from autoremove' -s n -d 'Show what would be removed'

--- a/completions/bru.zsh
+++ b/completions/bru.zsh
@@ -1,27 +1,110 @@
 #compdef bru
 
 _bru() {
-    local -a commands
-    commands=(
-        'install:Install a formula'
-        'uninstall:Uninstall a formula'
-        'upgrade:Upgrade outdated formulae'
-        'update:Fetch latest formulae data'
-        'search:Search for formulae'
-        'info:Show formula info'
-        'list:List installed formulae'
-        'deps:Show dependencies'
-        'uses:Show reverse dependencies'
-        'leaves:Show leaf formulae'
-        'autoremove:Remove orphaned deps'
-        'link:Symlink formula into prefix'
-        'unlink:Remove symlinks'
-        'cleanup:Remove old versions'
-        'outdated:Show outdated formulae'
-        'fetch:Download without installing'
-        'config:Show configuration'
+    local -a global_flags
+    global_flags=(
+        '--help[Show help]'
+        '--version[Show version]'
+        '--verbose[Enable verbose output]'
+        '--quiet[Quiet output]'
+        '--debug[Enable debug output]'
     )
-    _describe 'command' commands
+
+    _arguments -C \
+        '1:command:->command' \
+        '*::arg:->args'
+
+    case $state in
+        command)
+            local -a commands
+            commands=(
+                'install:Install a formula'
+                'uninstall:Uninstall a formula'
+                'upgrade:Upgrade outdated formulae'
+                'update:Fetch latest formulae data'
+                'search:Search for formulae'
+                'info:Show formula info'
+                'list:List installed formulae'
+                'deps:Show dependencies'
+                'uses:Show reverse dependencies'
+                'leaves:Show leaf formulae'
+                'autoremove:Remove orphaned deps'
+                'link:Symlink formula into prefix'
+                'unlink:Remove symlinks'
+                'cleanup:Remove old versions'
+                'outdated:Show outdated formulae'
+                'fetch:Download without installing'
+                'config:Show configuration'
+            )
+            _describe 'command' commands
+            _arguments $global_flags
+            ;;
+        args)
+            case ${words[1]} in
+                deps)
+                    _arguments \
+                        '--tree[Show as indented tree]' \
+                        '--1[Show only direct dependencies]' \
+                        '--direct[Show only direct dependencies]' \
+                        '--include-build[Include build-time dependencies]' \
+                        '--json[Output as JSON]' \
+                        '*:formula:_guard "^-*" formula'
+                    ;;
+                uses)
+                    _arguments \
+                        '--installed[Only show installed formulae]' \
+                        '--include-build[Include build-time dependency relationships]' \
+                        '*:formula:_guard "^-*" formula'
+                    ;;
+                list)
+                    _arguments \
+                        '--versions[Show version numbers]' \
+                        '--cask[Only casks]' \
+                        '--casks[Only casks]' \
+                        '--json[Output as JSON]' \
+                        '*:formula:_guard "^-*" formula'
+                    ;;
+                info)
+                    _arguments \
+                        '--json[Output as JSON]' \
+                        '*:formula:_guard "^-*" formula'
+                    ;;
+                search)
+                    _arguments \
+                        '--json[Output as JSON]' \
+                        '*:query:'
+                    ;;
+                leaves)
+                    _arguments \
+                        '--json[Output as JSON]'
+                    ;;
+                outdated)
+                    _arguments \
+                        '--verbose[Show version comparison]' \
+                        '--json[Output as JSON]'
+                    ;;
+                link)
+                    _arguments \
+                        '--force[Force linking of keg-only formulae]' \
+                        '*:formula:_guard "^-*" formula'
+                    ;;
+                cleanup)
+                    _arguments \
+                        '--dry-run[Show what would be removed]' \
+                        '-n[Show what would be removed]' \
+                        '--prune=[Override default retention (days)]:days:'
+                    ;;
+                autoremove)
+                    _arguments \
+                        '--dry-run[Show what would be removed]' \
+                        '-n[Show what would be removed]'
+                    ;;
+                install|uninstall|unlink|upgrade|fetch)
+                    _arguments '*:formula:_guard "^-*" formula'
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 _bru "$@"


### PR DESCRIPTION
## Summary
- Add per-command flag tab-completions for all subcommands in bash, zsh, and fish
- Add global flag completions (--help, --version, --verbose, --quiet, --debug)

Closes #9