### PR TITLE
feat: warn when --tree and --json are combined in deps

### DIFF
--- a/src/cmd/deps.zig
+++ b/src/cmd/deps.zig
@@ -40,6 +40,15 @@ pub fn depsCmd(allocator: Allocator, args: []const []const u8, config: Config) a
         }
     }
 
+    if (tree_mode and json_output) {
+        var warn_buf: [4096]u8 = undefined;
+        var ww = std.fs.File.stderr().writer(&warn_buf);
+        const warn_w = &ww.interface;
+        try warn_w.print("Warning: --tree is ignored when --json is specified\n", .{});
+        try warn_w.flush();
+        tree_mode = false;
+    }
+
     if (formula_name == null) {
         var err_buf: [4096]u8 = undefined;
         var ew = std.fs.File.stderr().writer(&err_buf);


### PR DESCRIPTION
## Summary

- Adds a stderr warning when `--tree` and `--json` are both passed to `bru deps`, since `--tree` is silently ignored in JSON mode
- Explicitly sets `tree_mode = false` so the code path is unambiguous

Closes #11

## Test plan

- [ ] `bru deps --tree --json <formula>` prints `Warning: --tree is ignored when --json is specified` to stderr and outputs valid JSON
- [ ] `bru deps --tree <formula>` still works as before
- [ ] `bru deps --json <formula>` still works as before
- [ ] All existing tests pass (`zig build test`)