### PR TITLE
test: add integration test for cask index loadOrBuild

### DIFF
--- a/src/cask_index.zig
+++ b/src/cask_index.zig
@@ -445,6 +445,29 @@ test "lookup missing returns null" {
     try std.testing.expect(idx.lookup("firefoxes") == null);
 }
 
+test "loadOrBuild from real cache" {
+    const allocator = std.testing.allocator;
+
+    const home = std.posix.getenv("HOME") orelse return;
+    var buf: [512]u8 = undefined;
+    const cache_dir = std.fmt.bufPrint(&buf, "{s}/Library/Caches/Homebrew", .{home}) catch return;
+
+    // Delete any existing .idx file so we exercise the full build path.
+    var idx_buf: [1024]u8 = undefined;
+    const idx_path = std.fmt.bufPrint(&idx_buf, "{s}/api/cask.bru.idx", .{cache_dir}) catch return;
+    std.fs.deleteFileAbsolute(idx_path) catch {};
+
+    var idx = CaskIndex.loadOrBuild(allocator, cache_dir) catch return;
+    defer idx.deinit();
+
+    // Should have >1000 cask entries.
+    try std.testing.expect(idx.entryCount() > 1000);
+
+    // Lookup "firefox".
+    const entry = idx.lookup("firefox") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("firefox", idx.getString(entry.token_offset));
+}
+
 test "deprecated and disabled flags" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
## Summary
- Adds an integration test for `CaskIndex.loadOrBuild` that exercises the full pipeline (JWS parse → build → write) against the real Homebrew cache on disk
- Follows the existing pattern from `src/index.zig` ("loadOrBuild from real cache")
- Skips gracefully when Homebrew cache is not available (CI-safe)

Closes #12

## Test plan
- [x] `zig build test` passes (90/90 tests)
- [x] Test verifies `entryCount() > 1000` casks
- [x] Test verifies lookup of "firefox" returns a valid entry
- [x] Test skips gracefully when `HOME` is unset or cache is missing