### PR TITLE
feat: use section headers in search output instead of (cask) suffix

### DIFF
--- a/src/cmd/search.zig
+++ b/src/cmd/search.zig
@@ -128,15 +128,7 @@ pub fn searchCmd(allocator: Allocator, args: []const []const u8, config: Config)
         return;
     }
 
-    for (formula_matches.items) |name| {
-        try stdout.print("{s}\n", .{name});
-    }
-    if (formula_matches.items.len > 0 and cask_matches.items.len > 0) {
-        try stdout.print("\n", .{});
-    }
-    for (cask_matches.items) |name| {
-        try stdout.print("{s} (cask)\n", .{name});
-    }
+    try writeSearchResults(stdout, formula_matches.items, cask_matches.items);
     try stdout.flush();
 
     if (formula_matches.items.len == 0 and cask_matches.items.len == 0) {
@@ -154,9 +146,106 @@ fn stringLessThan(_: void, a: []const u8, b: []const u8) bool {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write non-JSON search results to the given writer using brew-style section
+/// headers when both formulae and cask matches are present.
+fn writeSearchResults(writer: anytype, formula_matches: []const []const u8, cask_matches: []const []const u8) !void {
+    const both = formula_matches.len > 0 and cask_matches.len > 0;
+
+    if (both) {
+        try writer.writeAll("==> Formulae\n");
+    }
+    for (formula_matches) |name| {
+        try writer.print("{s}\n", .{name});
+    }
+    if (both) {
+        try writer.writeAll("\n==> Casks\n");
+    }
+    for (cask_matches) |name| {
+        try writer.print("{s}\n", .{name});
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 test "searchCmd compiles and has correct signature" {
     // Smoke test: verifies the function signature is correct and the module compiles.
+}
+
+test "search output: mixed results show section headers" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const writer = fbs.writer();
+
+    try writeSearchResults(writer, &.{ "firefoxpwa" }, &.{ "firefox", "firefox@beta" });
+
+    const output = fbs.getWritten();
+    const expected =
+        \\==> Formulae
+        \\firefoxpwa
+        \\
+        \\==> Casks
+        \\firefox
+        \\firefox@beta
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "search output: formula-only results have no headers" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const writer = fbs.writer();
+
+    try writeSearchResults(writer, &.{ "bat", "bat-extras" }, &.{});
+
+    const output = fbs.getWritten();
+    const expected =
+        \\bat
+        \\bat-extras
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "search output: cask-only results have no headers" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const writer = fbs.writer();
+
+    try writeSearchResults(writer, &.{}, &.{ "firefox", "firefox@beta" });
+
+    const output = fbs.getWritten();
+    const expected =
+        \\firefox
+        \\firefox@beta
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "search output: no (cask) suffix in output" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const writer = fbs.writer();
+
+    try writeSearchResults(writer, &.{"firefoxpwa"}, &.{ "firefox", "firefox@beta" });
+
+    const output = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, output, "(cask)") == null);
+}
+
+test "search output: no results produces no output" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const writer = fbs.writer();
+
+    try writeSearchResults(writer, &.{}, &.{});
+
+    const output = fbs.getWritten();
+    try std.testing.expectEqualStrings("", output);
 }

--- a/test/compat/compare.sh
+++ b/test/compat/compare.sh
@@ -82,7 +82,7 @@ compare "list" list
 compare "list --versions" list --versions
 compare "leaves" leaves
 compare_exact "outdated" outdated
-compare "search bat" search bat
+compare_exact "search bat" search bat
 compare_exact "deps bat" deps bat
 compare_loose "info bat" info bat
 compare "uses libgit2 --installed" uses libgit2 --installed


### PR DESCRIPTION
## Summary
- Replace `(cask)` suffix with brew-style `==> Formulae` and `==> Casks` section headers when both formula and cask matches are present
- Show no headers when only one type has results, matching real `brew search` behavior
- Extract `writeSearchResults` helper for testable, reusable formatting logic
- Update compat test to use exact comparison since output now matches brew format

Closes #13

## Test plan
- [x] Unit tests for mixed results (both formulae and casks) show section headers with blank line separator
- [x] Unit tests for formula-only and cask-only results print names without headers
- [x] Unit test verifies no `(cask)` suffix appears in output
- [x] Unit test for empty results produces no output
- [x] All existing tests pass (`zig build test`)
- [ ] Compat test `compare_exact "search bat"` matches `brew search bat` output