### PR TITLE
feat: add --timing flag and -Dtrace profiling for install

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const enable_trace = b.option(bool, "trace", "Emit Chrome Trace JSON for profiling") orelse false;
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "trace", enable_trace);
+
     const exe = b.addExecutable(.{
         .name = "bru",
         .root_module = b.createModule(.{
@@ -12,6 +17,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe.root_module.addOptions("build_options", build_options);
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);
@@ -29,6 +35,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    unit_tests.root_module.addOptions("build_options", build_options);
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -12,6 +12,9 @@ const Tab = tab_mod.Tab;
 const RuntimeDep = tab_mod.RuntimeDep;
 const Output = @import("../output.zig").Output;
 const fuzzy = @import("../fuzzy.zig");
+const timer_mod = @import("../timer.zig");
+const Timer = timer_mod.Timer;
+const Trace = timer_mod.Trace;
 
 /// Install a formula from a pre-built bottle.
 ///
@@ -41,8 +44,18 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
 
+    // Initialize trace for timing/profiling.
+    var trace = Trace.init(allocator, config.timing);
+    defer trace.deinit();
+    trace.formula_name = name;
+
+    // Start total timer.
+    var total_timer = Timer.start(&trace, "total");
+
     // 2. Look up in index.
+    var index_timer = Timer.start(&trace, "index");
     var idx = try Index.loadOrBuild(allocator, config.cache);
+    index_timer.stop();
     // Note: do not call idx.deinit() -- the index may be mmap'd (from disk)
     // in which case the allocator field is undefined. The process exits after
     // this command so OS reclamation is sufficient.
@@ -66,6 +79,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     }
 
     // 4. Check and install dependencies.
+    var deps_timer = Timer.start(&trace, "deps");
     {
         const dep_names_for_install = try idx.getStringList(allocator, entry.deps_offset);
         defer allocator.free(dep_names_for_install);
@@ -93,6 +107,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
             out.print("\n", .{});
         }
     }
+    deps_timer.stop();
 
     // 5. Check bottle availability.
     const bottle_root_url = idx.getString(entry.bottle_root_url_offset);
@@ -121,18 +136,26 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     out.print("Downloading {s}...\n", .{name});
 
     var dl = Download.init(allocator, config.cache);
+
+    var download_timer = Timer.start(&trace, "download");
     const archive_path = try dl.fetchBottle(url, name, bottle_sha256);
+    download_timer.stop();
     defer allocator.free(archive_path);
 
     // 8. Extract bottle.
     out.print("Pouring {s} {s}...\n", .{ name, version });
 
     var bottle = Bottle.init(allocator, config);
+
+    var extract_timer = Timer.start(&trace, "extract");
     const keg_path = try bottle.pour(archive_path, name, version);
+    extract_timer.stop();
     defer allocator.free(keg_path);
 
     // 9. Replace placeholders.
+    var placeholders_timer = Timer.start(&trace, "placeholders");
     try bottle.replacePlaceholders(keg_path);
+    placeholders_timer.stop();
 
     // 10. Build runtime_dependencies from the formula's dependency list.
     const dep_names = try idx.getStringList(allocator, entry.deps_offset);
@@ -178,6 +201,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     }
 
     // 11. Write install receipt (tab).
+    var receipt_timer = Timer.start(&trace, "receipt");
     const tab = Tab{
         .installed_on_request = true,
         .poured_from_bottle = true,
@@ -189,8 +213,10 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
         .source_tap = "homebrew/core",
     };
     try tab.writeToKeg(allocator, keg_path);
+    receipt_timer.stop();
 
     // 12. Link into prefix.
+    var link_timer = Timer.start(&trace, "link");
     const keg_only = (entry.flags & 1) != 0;
     var linker = Linker.init(allocator, config.prefix);
 
@@ -199,6 +225,16 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     } else {
         try linker.link(name, keg_path);
     }
+    link_timer.stop();
+
+    // Stop total timer.
+    total_timer.stop();
+
+    // Print timing breakdown if --timing was set.
+    trace.printTimings();
+
+    // Write trace file if -Dtrace was set at build time.
+    trace.writeTraceFile("bru-trace.json");
 
     // 13. Print completion.
     const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is installed", .{ name, version });

--- a/src/config.zig
+++ b/src/config.zig
@@ -13,6 +13,7 @@ pub const Config = struct {
     verbose: bool,
     debug: bool,
     quiet: bool,
+    timing: bool,
 
     allocator: Allocator,
 
@@ -67,6 +68,7 @@ pub const Config = struct {
             .verbose = false,
             .debug = false,
             .quiet = false,
+            .timing = false,
             .allocator = allocator,
         };
     }

--- a/src/dispatch.zig
+++ b/src/dispatch.zig
@@ -27,6 +27,7 @@ pub const ParsedArgs = struct {
     verbose: bool,
     debug: bool,
     quiet: bool,
+    timing: bool,
     help: bool,
     version: bool,
 };
@@ -80,6 +81,7 @@ pub fn parseArgs(argv: []const []const u8) ParsedArgs {
         .verbose = false,
         .debug = false,
         .quiet = false,
+        .timing = false,
         .help = false,
         .version = false,
     };
@@ -105,6 +107,11 @@ pub fn parseArgs(argv: []const []const u8) ParsedArgs {
         }
         if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             result.quiet = true;
+            i += 1;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--timing")) {
+            result.timing = true;
             i += 1;
             continue;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,7 @@ pub fn main() !void {
     if (parsed.verbose) cfg.verbose = true;
     if (parsed.debug) cfg.debug = true;
     if (parsed.quiet) cfg.quiet = true;
+    if (parsed.timing) cfg.timing = true;
 
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
@@ -107,4 +108,5 @@ test {
     _ = @import("linker.zig");
     _ = @import("json_helpers.zig");
     _ = @import("fuzzy.zig");
+    _ = @import("timer.zig");
 }

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const build_options = @import("build_options");
+
+/// A lightweight span timer for profiling install phases.
+///
+/// When `--timing` is active, `stop()` records the elapsed time for later
+/// printing to stderr. When `-Dtrace` is set at build time, spans are also
+/// collected for Chrome Trace Format JSON output.
+pub const Timer = struct {
+    label: []const u8,
+    start_ns: i128,
+    parent: *Trace,
+
+    pub fn start(trace: *Trace, label: []const u8) Timer {
+        return .{
+            .label = label,
+            .start_ns = std.time.nanoTimestamp(),
+            .parent = trace,
+        };
+    }
+
+    pub fn stop(self: *Timer) void {
+        const end_ns = std.time.nanoTimestamp();
+        const elapsed_ns = end_ns - self.start_ns;
+
+        if (self.parent.enabled) {
+            self.parent.timing_spans.append(self.parent.allocator, .{
+                .label = self.label,
+                .elapsed_ns = elapsed_ns,
+            }) catch {};
+        }
+
+        if (build_options.trace) {
+            if (self.parent.trace_enabled) {
+                const start_us: i64 = @intCast(@divTrunc(self.start_ns - self.parent.process_start, 1000));
+                const dur_us: i64 = @intCast(@divTrunc(elapsed_ns, 1000));
+                self.parent.trace_spans.append(self.parent.allocator, .{
+                    .name = self.label,
+                    .ts = start_us,
+                    .dur = dur_us,
+                }) catch {};
+            }
+        }
+    }
+};
+
+/// A named timing entry recorded when `--timing` is active.
+const TimingSpan = struct {
+    label: []const u8,
+    elapsed_ns: i128,
+};
+
+/// A Chrome Trace Format span recorded when `-Dtrace` is set.
+const TraceSpan = struct {
+    name: []const u8,
+    ts: i64, // microseconds from process start
+    dur: i64, // duration in microseconds
+};
+
+/// Collects timing data and optional trace spans across an operation.
+pub const Trace = struct {
+    enabled: bool, // --timing flag
+    trace_enabled: bool, // comptime -Dtrace (runtime toggle)
+    allocator: Allocator,
+    process_start: i128,
+    timing_spans: std.ArrayListUnmanaged(TimingSpan),
+    trace_spans: std.ArrayListUnmanaged(TraceSpan),
+    formula_name: []const u8,
+
+    pub fn init(allocator: Allocator, timing: bool) Trace {
+        return .{
+            .enabled = timing,
+            .trace_enabled = build_options.trace,
+            .allocator = allocator,
+            .process_start = std.time.nanoTimestamp(),
+            .timing_spans = .{},
+            .trace_spans = .{},
+            .formula_name = "",
+        };
+    }
+
+    pub fn deinit(self: *Trace) void {
+        self.timing_spans.deinit(self.allocator);
+        self.trace_spans.deinit(self.allocator);
+    }
+
+    /// Print the timing breakdown to stderr.
+    pub fn printTimings(self: *const Trace) void {
+        if (!self.enabled or self.timing_spans.items.len == 0) return;
+
+        var err_buf: [4096]u8 = undefined;
+        var ew = std.fs.File.stderr().writer(&err_buf);
+        const stderr = &ew.interface;
+
+        stderr.print("\n==> Timing: {s}\n", .{self.formula_name}) catch return;
+
+        for (self.timing_spans.items) |span| {
+            const ms = @divTrunc(span.elapsed_ns, 1_000_000);
+            stderr.print("  {s:<16} {d}ms\n", .{ span.label, ms }) catch return;
+        }
+
+        stderr.flush() catch {};
+    }
+
+    /// Write Chrome Trace Format JSON to the given path.
+    pub fn writeTraceFile(self: *const Trace, path: []const u8) void {
+        if (!build_options.trace) return;
+        if (self.trace_spans.items.len == 0) return;
+
+        const file = std.fs.cwd().createFile(path, .{}) catch return;
+        defer file.close();
+
+        var buf: [8192]u8 = undefined;
+        var bw = file.writer(&buf);
+        const w = &bw.interface;
+
+        w.print("[\n", .{}) catch return;
+
+        for (self.trace_spans.items, 0..) |span, i| {
+            if (i > 0) {
+                w.print(",\n", .{}) catch return;
+            }
+            w.print(
+                \\  {{"name":"{s}","ph":"X","ts":{d},"dur":{d},"pid":1,"tid":1}}
+            , .{ span.name, span.ts, span.dur }) catch return;
+        }
+
+        w.print("\n]\n", .{}) catch return;
+        w.flush() catch return;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "timer start and stop records timing span" {
+    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa_instance.deinit();
+    const allocator = gpa_instance.allocator();
+
+    var trace = Trace.init(allocator, true);
+    defer trace.deinit();
+
+    var t = Timer.start(&trace, "test_phase");
+    t.stop();
+
+    try std.testing.expectEqual(@as(usize, 1), trace.timing_spans.items.len);
+    try std.testing.expectEqualStrings("test_phase", trace.timing_spans.items[0].label);
+    try std.testing.expect(trace.timing_spans.items[0].elapsed_ns >= 0);
+}
+
+test "timer no-op when timing disabled" {
+    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa_instance.deinit();
+    const allocator = gpa_instance.allocator();
+
+    var trace = Trace.init(allocator, false);
+    defer trace.deinit();
+
+    var t = Timer.start(&trace, "ignored");
+    t.stop();
+
+    try std.testing.expectEqual(@as(usize, 0), trace.timing_spans.items.len);
+}
+
+test "trace init sets fields correctly" {
+    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa_instance.deinit();
+    const allocator = gpa_instance.allocator();
+
+    var trace = Trace.init(allocator, true);
+    defer trace.deinit();
+
+    try std.testing.expect(trace.enabled);
+    try std.testing.expectEqual(build_options.trace, trace.trace_enabled);
+    try std.testing.expectEqual(@as(usize, 0), trace.timing_spans.items.len);
+}

--- a/test/benchmark/bench_flamegraph.sh
+++ b/test/benchmark/bench_flamegraph.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# bench_flamegraph.sh — Build with -Dtrace, run install, produce Chrome Trace JSON.
+#
+# Usage: bash test/benchmark/bench_flamegraph.sh [options] [formula]
+#   formula   Package to profile (default: libsodium)
+#   --warm    Skip cache clearing (profile warm install)
+#   --open    Auto-open trace in Perfetto (macOS)
+#   --dry-run Preview commands without executing
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BRU="$PROJECT_ROOT/zig-out/bin/bru"
+TRACE_FILE="$PROJECT_ROOT/bru-trace.json"
+
+DEFAULT_FORMULA="libsodium"
+FORMULA=""
+WARM=false
+OPEN=false
+DRY_RUN=false
+
+# ── Parse arguments ──────────────────────────────────────────────────
+
+for arg in "$@"; do
+    case "$arg" in
+        --warm)    WARM=true ;;
+        --open)    OPEN=true ;;
+        --dry-run) DRY_RUN=true ;;
+        -*)        echo "Unknown option: $arg" >&2; exit 1 ;;
+        *)         FORMULA="$arg" ;;
+    esac
+done
+
+FORMULA="${FORMULA:-$DEFAULT_FORMULA}"
+
+HOMEBREW_CACHE="${HOMEBREW_CACHE:-$(brew --cache 2>/dev/null || echo "$HOME/Library/Caches/Homebrew")}"
+HOMEBREW_CELLAR="${HOMEBREW_CELLAR:-$(brew --cellar 2>/dev/null || echo "/opt/homebrew/Cellar")}"
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+uninstall_formula() {
+    local formula="$1"
+    if brew list --formula "$formula" &>/dev/null; then
+        brew uninstall --ignore-dependencies "$formula" &>/dev/null || true
+    fi
+}
+
+clear_cache() {
+    local formula="$1"
+    find "$HOMEBREW_CACHE/downloads" -name "*--${formula}*" -delete 2>/dev/null || true
+}
+
+ensure_deps_installed() {
+    local formula="$1"
+    local deps
+    deps=$(brew deps "$formula" 2>/dev/null) || return 0
+    if [ -n "$deps" ]; then
+        echo "  Pre-installing deps: $deps"
+        if $DRY_RUN; then return 0; fi
+        for dep in $deps; do
+            if ! brew list --formula "$dep" &>/dev/null; then
+                brew install "$dep" >/dev/null 2>&1
+            fi
+        done
+    fi
+}
+
+# ── Safety checks ────────────────────────────────────────────────────
+
+if ! $DRY_RUN && ! command -v brew &>/dev/null; then
+    die "brew not found in PATH"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────
+
+echo "Building bru with -Dtrace -Doptimize=ReleaseFast..."
+if $DRY_RUN; then
+    echo "  [dry-run] would run: zig build -Doptimize=ReleaseFast -Dtrace=true"
+else
+    cd "$PROJECT_ROOT"
+    zig build -Doptimize=ReleaseFast -Dtrace=true
+fi
+
+if ! $DRY_RUN && [ ! -x "$BRU" ]; then
+    die "bru not found at $BRU"
+fi
+
+# ── Prepare ──────────────────────────────────────────────────────────
+
+echo ""
+echo "Profiling: $FORMULA"
+
+ensure_deps_installed "$FORMULA"
+
+if $DRY_RUN; then
+    if ! $WARM; then
+        echo "  [dry-run] would clear cache for $FORMULA"
+    fi
+    echo "  [dry-run] would uninstall $FORMULA"
+    echo "  [dry-run] would run: $BRU install $FORMULA"
+    echo "  [dry-run] trace file: $TRACE_FILE"
+    exit 0
+fi
+
+# Uninstall target
+uninstall_formula "$FORMULA"
+
+# Clear cache unless --warm
+if ! $WARM; then
+    echo "  Clearing cache (cold install)..."
+    clear_cache "$FORMULA"
+else
+    echo "  Keeping cache (warm install)..."
+fi
+
+# ── Run ──────────────────────────────────────────────────────────────
+
+echo "  Running: $BRU install $FORMULA"
+echo ""
+
+# Remove old trace file
+rm -f "$TRACE_FILE"
+
+"$BRU" install "$FORMULA"
+
+echo ""
+
+# ── Report ───────────────────────────────────────────────────────────
+
+if [ -f "$TRACE_FILE" ]; then
+    echo "Trace file: $TRACE_FILE"
+    echo "Open in browser: https://ui.perfetto.dev/"
+    echo ""
+
+    if $OPEN; then
+        echo "Opening in Perfetto..."
+        open "https://ui.perfetto.dev/"
+        echo "Drag $TRACE_FILE into the Perfetto UI to view the trace."
+    fi
+else
+    echo "No trace file generated. Ensure bru was built with -Dtrace=true."
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────────────
+
+uninstall_formula "$FORMULA"

--- a/test/benchmark/bench_install.sh
+++ b/test/benchmark/bench_install.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BRU="$PROJECT_ROOT/zig-out/bin/bru"
+
+# Configurable package list
+DEFAULT_PACKAGES="ffmpeg libsodium duckdb tesseract"
+PACKAGES="${PACKAGES:-$DEFAULT_PACKAGES}"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+fi
+
+HOMEBREW_CACHE="${HOMEBREW_CACHE:-$(brew --cache)}"
+HOMEBREW_CELLAR="${HOMEBREW_CELLAR:-$(brew --cellar)}"
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+# Time a single install in milliseconds.
+# Usage: time_install <bin> <formula>
+time_install() {
+    local bin="$1" formula="$2"
+    local secs
+    secs=$( { TIMEFORMAT='%R'; time $bin install "$formula" >/dev/null 2>&1; } 2>&1 )
+    awk "BEGIN {printf \"%d\", $secs * 1000}"
+}
+
+# Uninstall a formula (ignoring dependencies).
+uninstall_formula() {
+    local formula="$1"
+    if brew list --formula "$formula" &>/dev/null; then
+        brew uninstall --ignore-dependencies "$formula" &>/dev/null || true
+    fi
+}
+
+# Remove cached downloads matching formula name.
+# brew caches as: {sha256}--{name}--{version}.{arch}.bottle.tar.gz
+# bru  caches as: {sha256}--{name}
+# The pattern *--{name}* covers both.
+clear_cache() {
+    local formula="$1"
+    find "$HOMEBREW_CACHE/downloads" -name "*--${formula}*" -delete 2>/dev/null || true
+}
+
+# Pre-install all dependencies of a formula so we only benchmark the target.
+ensure_deps_installed() {
+    local formula="$1"
+    local deps
+    deps=$(brew deps "$formula" 2>/dev/null) || return 0
+    if [ -n "$deps" ]; then
+        echo "    pre-installing deps: $deps"
+        if $DRY_RUN; then return 0; fi
+        # Install missing deps only
+        for dep in $deps; do
+            if ! brew list --formula "$dep" &>/dev/null; then
+                brew install "$dep" >/dev/null 2>&1
+            fi
+        done
+    fi
+}
+
+# Print a formatted table row
+row() {
+    printf "│ %-14s │ %12s │ %12s │ %12s │ %12s │ %12s │ %12s │\n" "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+}
+
+separator() {
+    printf "├────────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┤\n"
+}
+
+# ── Safety checks ────────────────────────────────────────────────────
+
+if ! command -v brew &>/dev/null; then
+    die "brew not found in PATH"
+fi
+
+if [ ! -d "$HOMEBREW_CACHE" ]; then
+    die "Homebrew cache not found at $HOMEBREW_CACHE"
+fi
+
+if [ ! -d "$HOMEBREW_CELLAR" ]; then
+    die "Homebrew cellar not found at $HOMEBREW_CELLAR"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────
+
+echo "Building bru (ReleaseFast)..."
+if $DRY_RUN; then
+    echo "  [dry-run] would run: zig build -Doptimize=ReleaseFast"
+else
+    cd "$PROJECT_ROOT"
+    zig build -Doptimize=ReleaseFast
+fi
+
+if ! $DRY_RUN && [ ! -x "$BRU" ]; then
+    die "bru not found at $BRU"
+fi
+
+# ── Run benchmarks ──────────────────────────────────────────────────
+
+echo ""
+echo "Benchmarking install: bru vs brew"
+echo "Packages: $PACKAGES"
+echo ""
+
+declare -a PKG_NAMES BREW_COLD_TIMES BREW_WARM_TIMES BRU_COLD_TIMES BRU_WARM_TIMES
+
+for formula in $PACKAGES; do
+    echo "[$formula]"
+
+    # 0. Pre-install dependencies
+    ensure_deps_installed "$formula"
+
+    if $DRY_RUN; then
+        echo "    [dry-run] brew cold: uninstall + clear cache + brew install $formula"
+        echo "    [dry-run] brew warm: uninstall + keep cache  + brew install $formula"
+        echo "    [dry-run] bru cold:  uninstall + clear cache + bru install $formula"
+        echo "    [dry-run] bru warm:  uninstall + keep cache  + bru install $formula"
+        echo "    [dry-run] cleanup:   uninstall $formula"
+        PKG_NAMES+=("$formula")
+        BREW_COLD_TIMES+=(0)
+        BREW_WARM_TIMES+=(0)
+        BRU_COLD_TIMES+=(0)
+        BRU_WARM_TIMES+=(0)
+        echo ""
+        continue
+    fi
+
+    # 1. brew cold: no cached bottle
+    echo -n "    brew cold ..."
+    uninstall_formula "$formula"
+    clear_cache "$formula"
+    brew_cold=$(time_install brew "$formula")
+    echo " ${brew_cold}ms"
+
+    # 2. brew warm: bottle in cache
+    echo -n "    brew warm ..."
+    uninstall_formula "$formula"
+    brew_warm=$(time_install brew "$formula")
+    echo " ${brew_warm}ms"
+
+    # 3. bru cold: no cached bottle
+    echo -n "    bru cold  ..."
+    uninstall_formula "$formula"
+    clear_cache "$formula"
+    bru_cold=$(time_install "$BRU" "$formula")
+    echo " ${bru_cold}ms"
+
+    # 4. bru warm: bottle in cache
+    echo -n "    bru warm  ..."
+    uninstall_formula "$formula"
+    bru_warm=$(time_install "$BRU" "$formula")
+    echo " ${bru_warm}ms"
+
+    # 5. Cleanup
+    uninstall_formula "$formula"
+
+    PKG_NAMES+=("$formula")
+    BREW_COLD_TIMES+=("$brew_cold")
+    BREW_WARM_TIMES+=("$brew_warm")
+    BRU_COLD_TIMES+=("$bru_cold")
+    BRU_WARM_TIMES+=("$bru_warm")
+
+    echo ""
+done
+
+# ── Print results table ─────────────────────────────────────────────
+
+echo "┌────────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────┐"
+row "Package" "brew cold" "brew warm" "bru cold" "bru warm" "Cold Speedup" "Warm Speedup"
+echo "├────────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┤"
+
+total_brew_cold=0
+total_brew_warm=0
+total_bru_cold=0
+total_bru_warm=0
+
+for i in "${!PKG_NAMES[@]}"; do
+    bc="${BREW_COLD_TIMES[$i]}"
+    bw="${BREW_WARM_TIMES[$i]}"
+    rc="${BRU_COLD_TIMES[$i]}"
+    rw="${BRU_WARM_TIMES[$i]}"
+
+    total_brew_cold=$((total_brew_cold + bc))
+    total_brew_warm=$((total_brew_warm + bw))
+    total_bru_cold=$((total_bru_cold + rc))
+    total_bru_warm=$((total_bru_warm + rw))
+
+    if [ "$rc" -gt 0 ]; then
+        cold_speedup=$(awk "BEGIN {printf \"%.1fx\", $bc / $rc}")
+    else
+        cold_speedup="inf"
+    fi
+
+    if [ "$rw" -gt 0 ]; then
+        warm_speedup=$(awk "BEGIN {printf \"%.1fx\", $bw / $rw}")
+    else
+        warm_speedup="inf"
+    fi
+
+    row "${PKG_NAMES[$i]}" "${bc}ms" "${bw}ms" "${rc}ms" "${rw}ms" "$cold_speedup" "$warm_speedup"
+done
+
+separator
+
+if [ "$total_bru_cold" -gt 0 ]; then
+    total_cold_speedup=$(awk "BEGIN {printf \"%.1fx\", $total_brew_cold / $total_bru_cold}")
+else
+    total_cold_speedup="inf"
+fi
+
+if [ "$total_bru_warm" -gt 0 ]; then
+    total_warm_speedup=$(awk "BEGIN {printf \"%.1fx\", $total_brew_warm / $total_bru_warm}")
+else
+    total_warm_speedup="inf"
+fi
+
+row "TOTAL" "${total_brew_cold}ms" "${total_brew_warm}ms" "${total_bru_cold}ms" "${total_bru_warm}ms" "$total_cold_speedup" "$total_warm_speedup"
+echo "└────────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────┘"
+echo ""
+echo "Cold = no cached bottle (download + extract + link)"
+echo "Warm = bottle in cache (extract + link only)"


### PR DESCRIPTION
## Summary
- Add `--timing` global flag that prints per-phase timing breakdown to stderr after install
- Add `-Dtrace` build option that emits Chrome Trace Format JSON (`bru-trace.json`) for flame graph visualization in Perfetto
- Instrument 7 install phases: index, deps, download, extract, placeholders, receipt, link
- Add `bench_flamegraph.sh` dev profiling script and `bench_install.sh` benchmark script

## Test plan
- [x] `zig build test` — all existing tests pass
- [ ] `bru install libsodium` — works unchanged (no timing output)
- [ ] `bru --timing install libsodium` — prints phase timing table to stderr
- [ ] `zig build -Dtrace=true && bru install libsodium` — creates `bru-trace.json`
- [ ] `bash test/benchmark/bench_flamegraph.sh --dry-run` — preview works