### PR TITLE
perf: parallel dependency downloads for cold installs

### DIFF
--- a/docs/plans/2026-02-27-parallel-dependency-download-design.md
+++ b/docs/plans/2026-02-27-parallel-dependency-download-design.md
@@ -1,0 +1,66 @@
+# Parallel Dependency Download Design
+
+GitHub Issue: #22
+
+## Problem
+
+Download is 95-96% of cold install wall time. For packages with many deps (e.g. ffmpeg with 10 deps), each dep is downloaded sequentially despite being independent GHCR fetches.
+
+## Approach: Parallel Pre-fetch (Approach A)
+
+Before the sequential install loop, pre-download all missing bottles in parallel. The install loop runs unchanged — each `fetchBottle` call hits the download cache.
+
+## Design
+
+### Download Task
+
+```zig
+const DownloadTask = struct {
+    url: []const u8,
+    name: []const u8,
+    sha256: []const u8,
+};
+```
+
+### Pre-fetch Flow
+
+1. Use `collectTransitiveDeps` from `deps.zig` to get full transitive closure
+2. Filter to deps not already installed
+3. Include the target formula in the task list
+4. Look up `bottle_root_url` and `bottle_sha256` for each from the index
+5. Spawn `@min(4, tasks.len)` worker threads
+6. Each worker uses a shared atomic counter to grab the next task, calls `fetchBottle`, stores result
+7. Main thread joins all workers
+
+### Worker Pattern
+
+Shared `std.atomic.Value(usize)` starts at 0. Each worker:
+1. Atomically fetch-and-increment counter
+2. If index >= tasks.len, exit
+3. Call `Download.fetchBottle(task.url, task.name, task.sha256)`
+4. Store error (if any) in per-task result slot
+5. Goto 1
+
+Each worker gets its own `ArenaAllocator` backed by page allocator.
+
+### Error Handling
+
+Pre-fetch is opportunistic. Failed downloads are logged as warnings. The sequential install loop retries the download and surfaces the real error if it fails again.
+
+### Changes
+
+- **`src/cmd/install.zig`**: Add `prefetchBottles` function, call it before the install loop, add `"prefetch"` timer span. Import `collectTransitiveDeps` and threading primitives.
+- **`src/download.zig`**: No changes. Already stateless and thread-safe.
+- **Other files**: No changes.
+
+### Timing Output
+
+```
+==> Timing: ffmpeg
+  index            42ms
+  deps             1534ms
+    prefetch       1200ms
+  download         2ms       (cache hit)
+  extract          890ms
+  ...
+```

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -15,6 +15,7 @@ const fuzzy = @import("../fuzzy.zig");
 const timer_mod = @import("../timer.zig");
 const Timer = timer_mod.Timer;
 const Trace = timer_mod.Trace;
+const collectTransitiveDeps = @import("deps.zig").collectTransitiveDeps;
 
 /// Install a formula from a pre-built bottle.
 ///
@@ -94,6 +95,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
         }
 
         if (missing_deps.items.len > 0) {
+            prefetchBottles(allocator, &idx, cellar, name, config, &trace);
             out.section("Installing dependencies");
             for (missing_deps.items) |dep_name| {
                 out.print("Installing dependency: {s}...\n", .{dep_name});
@@ -240,6 +242,120 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is installed", .{ name, version });
     defer allocator.free(done_title);
     out.section(done_title);
+}
+
+// ---------------------------------------------------------------------------
+// Parallel bottle pre-fetch
+// ---------------------------------------------------------------------------
+
+const DownloadTask = struct {
+    url: []const u8,
+    name: []const u8,
+    sha256: []const u8,
+};
+
+const WorkerContext = struct {
+    tasks: []const DownloadTask,
+    next_index: *usize,
+    cache_dir: []const u8,
+};
+
+/// Worker thread: claims tasks via atomic counter and downloads bottles.
+/// Must not access shared mutable state (e.g. Trace) -- only the atomic
+/// next_index and immutable task data.
+fn downloadWorker(ctx: WorkerContext) void {
+    while (true) {
+        const i = @atomicRmw(usize, ctx.next_index, .Add, 1, .seq_cst);
+        if (i >= ctx.tasks.len) return;
+
+        const task = ctx.tasks[i];
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+
+        var dl = Download.init(arena.allocator(), ctx.cache_dir);
+        _ = dl.fetchBottle(task.url, task.name, task.sha256) catch continue;
+    }
+}
+
+fn addDownloadTask(
+    allocator: Allocator,
+    idx: *const Index,
+    tasks: *std.ArrayList(DownloadTask),
+    dep_name: []const u8,
+) !void {
+    const dep_entry = idx.lookup(dep_name) orelse return;
+    const bottle_root_url = idx.getString(dep_entry.bottle_root_url_offset);
+    const bottle_sha256 = idx.getString(dep_entry.bottle_sha256_offset);
+    if (bottle_root_url.len == 0 or bottle_sha256.len == 0) return;
+
+    const image_name = try download.ghcrImageName(allocator, dep_name);
+    defer allocator.free(image_name);
+
+    const url = try std.fmt.allocPrint(allocator, "{s}/{s}/blobs/sha256:{s}", .{
+        bottle_root_url, image_name, bottle_sha256,
+    });
+
+    try tasks.append(allocator, .{ .url = url, .name = dep_name, .sha256 = bottle_sha256 });
+}
+
+/// Pre-fetch bottles for all transitive missing dependencies (and the target
+/// formula) in parallel. This is best-effort: any failures are silently
+/// ignored because the sequential install loop will retry each download.
+fn prefetchBottles(
+    allocator: Allocator,
+    idx: *const Index,
+    cellar: Cellar,
+    name: []const u8,
+    config: Config,
+    trace: *Trace,
+) void {
+    // 1. Collect full transitive dependency closure.
+    var visited = std.StringHashMap(void).init(allocator);
+    defer visited.deinit();
+    var all_deps = std.ArrayList([]const u8){};
+    defer all_deps.deinit(allocator);
+    collectTransitiveDeps(idx, allocator, name, &visited, &all_deps, false) catch return;
+
+    // 2. Build download tasks for missing deps + target formula.
+    var tasks = std.ArrayList(DownloadTask){};
+    defer {
+        for (tasks.items) |task| allocator.free(task.url);
+        tasks.deinit(allocator);
+    }
+
+    for (all_deps.items) |dep_name| {
+        if (cellar.isInstalled(dep_name)) continue;
+        addDownloadTask(allocator, idx, &tasks, dep_name) catch continue;
+    }
+    addDownloadTask(allocator, idx, &tasks, name) catch {};
+
+    if (tasks.items.len == 0) return;
+
+    // 3. Spawn worker threads with shared atomic work index.
+    var prefetch_timer = Timer.start(trace, "prefetch");
+
+    const max_workers = 4;
+    const worker_count = @min(max_workers, tasks.items.len);
+    // next_index and tasks.items are safe to share because we join all
+    // threads before this function returns (so they outlive the workers).
+    var next_index: usize = 0;
+    const ctx = WorkerContext{
+        .tasks = tasks.items,
+        .next_index = &next_index,
+        .cache_dir = config.cache,
+    };
+
+    var threads: [max_workers]std.Thread = undefined;
+    var spawned: usize = 0;
+    for (0..worker_count) |i| {
+        threads[i] = std.Thread.spawn(.{}, downloadWorker, .{ctx}) catch break;
+        spawned += 1;
+    }
+    for (0..spawned) |i| {
+        threads[i].join();
+    }
+
+    prefetch_timer.stop();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pre-fetch all missing dependency bottles concurrently (up to 4 threads) before the sequential install loop
- Downloads land in the cache so each dependency install gets a cache hit instead of a cold download
- Best-effort: prefetch failures are silently ignored; the sequential loop retries normally

Closes #22