### PR TITLE
perf: HTTP connection pooling for GHCR bottle fetches

### DIFF
--- a/src/cmd/fetch_cmd.zig
+++ b/src/cmd/fetch_cmd.zig
@@ -4,6 +4,7 @@ const Config = @import("../config.zig").Config;
 const Index = @import("../index.zig").Index;
 const download = @import("../download.zig");
 const Download = download.Download;
+const HttpClient = @import("../http.zig").HttpClient;
 const Output = @import("../output.zig").Output;
 
 /// Download a bottle for a formula without installing it.
@@ -57,7 +58,10 @@ pub fn fetchCmd(allocator: Allocator, args: []const []const u8, config: Config) 
     defer allocator.free(section_title);
     out.section(section_title);
 
-    var dl = Download.init(allocator, config.cache);
+    var http_client = HttpClient.init(allocator);
+    defer http_client.deinit();
+
+    var dl = Download.init(allocator, config.cache, &http_client);
     const cached_path = try dl.fetchBottle(url, formula_name, bottle_sha256);
     defer allocator.free(cached_path);
 

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -15,6 +15,7 @@ const fuzzy = @import("../fuzzy.zig");
 const timer_mod = @import("../timer.zig");
 const Timer = timer_mod.Timer;
 const Trace = timer_mod.Trace;
+const HttpClient = @import("../http.zig").HttpClient;
 const collectTransitiveDeps = @import("deps.zig").collectTransitiveDeps;
 
 /// Install a formula from a pre-built bottle.
@@ -49,6 +50,9 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     var trace = Trace.init(allocator, config.timing);
     defer trace.deinit();
     trace.formula_name = name;
+
+    var http_client = HttpClient.init(allocator);
+    defer http_client.deinit();
 
     // Start total timer.
     var total_timer = Timer.start(&trace, "total");
@@ -95,7 +99,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
         }
 
         if (missing_deps.items.len > 0) {
-            prefetchBottles(allocator, &idx, cellar, name, config, &trace);
+            prefetchBottles(allocator, &idx, cellar, name, config, &trace, &http_client);
             out.section("Installing dependencies");
             for (missing_deps.items) |dep_name| {
                 out.print("Installing dependency: {s}...\n", .{dep_name});
@@ -137,7 +141,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     out.print("Downloading {s}...\n", .{name});
 
-    var dl = Download.init(allocator, config.cache);
+    var dl = Download.init(allocator, config.cache, &http_client);
 
     var download_timer = Timer.start(&trace, "download");
     const archive_path = try dl.fetchBottle(url, name, bottle_sha256);
@@ -258,6 +262,7 @@ const WorkerContext = struct {
     tasks: []const DownloadTask,
     next_index: *usize,
     cache_dir: []const u8,
+    http_client: *HttpClient,
 };
 
 /// Worker thread: claims tasks via atomic counter and downloads bottles.
@@ -272,7 +277,7 @@ fn downloadWorker(ctx: WorkerContext) void {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
 
-        var dl = Download.init(arena.allocator(), ctx.cache_dir);
+        var dl = Download.init(arena.allocator(), ctx.cache_dir, ctx.http_client);
         _ = dl.fetchBottle(task.url, task.name, task.sha256) catch continue;
     }
 }
@@ -308,6 +313,7 @@ fn prefetchBottles(
     name: []const u8,
     config: Config,
     trace: *Trace,
+    http_client: *HttpClient,
 ) void {
     // 1. Collect full transitive dependency closure.
     var visited = std.StringHashMap(void).init(allocator);
@@ -343,6 +349,7 @@ fn prefetchBottles(
         .tasks = tasks.items,
         .next_index = &next_index,
         .cache_dir = config.cache,
+        .http_client = http_client,
     };
 
     var threads: [max_workers]std.Thread = undefined;

--- a/src/cmd/update.zig
+++ b/src/cmd/update.zig
@@ -38,7 +38,8 @@ pub fn updateCmd(allocator: Allocator, args: []const []const u8, config: Config)
     };
 
     // Download fresh formula.jws.json from the Homebrew API.
-    const client = HttpClient.init(allocator);
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
     client.fetch("https://formulae.brew.sh/api/formula.jws.json", jws_path) catch |err| {
         const err_out = Output.initErr(config.no_color);
         err_out.err("Failed to download formula data: {s}", .{@errorName(err)});

--- a/src/download.zig
+++ b/src/download.zig
@@ -4,9 +4,10 @@ const HttpClient = @import("http.zig").HttpClient;
 pub const Download = struct {
     allocator: std.mem.Allocator,
     cache_dir: []const u8,
+    http_client: *HttpClient,
 
-    pub fn init(allocator: std.mem.Allocator, cache_dir: []const u8) Download {
-        return .{ .allocator = allocator, .cache_dir = cache_dir };
+    pub fn init(allocator: std.mem.Allocator, cache_dir: []const u8, http_client: *HttpClient) Download {
+        return .{ .allocator = allocator, .cache_dir = cache_dir, .http_client = http_client };
     }
 
     /// Return the cache path for a URL.
@@ -42,8 +43,7 @@ pub const Download = struct {
         };
 
         // Download via HttpClient.fetchGhcr.
-        const client = HttpClient.init(self.allocator);
-        try client.fetchGhcr(url, path);
+        try self.http_client.fetchGhcr(url, path);
 
         // Verify checksum after download.
         const valid = try verifySha256(path, expected_sha256);
@@ -104,7 +104,9 @@ pub fn ghcrImageName(allocator: std.mem.Allocator, name: []const u8) ![]const u8
 
 test "cachePath produces deterministic path" {
     const allocator = std.testing.allocator;
-    const dl = Download.init(allocator, "/tmp/bru-test-cache");
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
+    const dl = Download.init(allocator, "/tmp/bru-test-cache", &client);
 
     const path1 = try dl.cachePath("https://example.com/bottle.tar.gz", "myformula");
     defer allocator.free(path1);

--- a/src/http.zig
+++ b/src/http.zig
@@ -2,25 +2,30 @@ const std = @import("std");
 
 pub const HttpClient = struct {
     allocator: std.mem.Allocator,
+    client: std.http.Client,
 
     pub fn init(allocator: std.mem.Allocator) HttpClient {
-        return .{ .allocator = allocator };
+        return .{ .allocator = allocator, .client = .{ .allocator = allocator } };
+    }
+
+    pub fn deinit(self: *HttpClient) void {
+        self.client.deinit();
     }
 
     /// Download a URL to a file path.
-    pub fn fetch(self: HttpClient, url: []const u8, dest_path: []const u8) !void {
+    pub fn fetch(self: *HttpClient, url: []const u8, dest_path: []const u8) !void {
         try self.fetchInner(url, dest_path, .{}, &.{});
     }
 
     /// Download from GHCR with anonymous auth header (Authorization: Bearer QQ==).
-    pub fn fetchGhcr(self: HttpClient, url: []const u8, dest_path: []const u8) !void {
+    pub fn fetchGhcr(self: *HttpClient, url: []const u8, dest_path: []const u8) !void {
         try self.fetchInner(url, dest_path, .{
             .authorization = .{ .override = "Bearer QQ==" },
         }, &.{});
     }
 
     fn fetchInner(
-        self: HttpClient,
+        self: *HttpClient,
         url: []const u8,
         dest_path: []const u8,
         headers: std.http.Client.Request.Headers,
@@ -40,16 +45,12 @@ pub const HttpClient = struct {
         const file = try std.fs.cwd().createFile(dest_path, .{});
         defer file.close();
 
-        // Set up HTTP client.
-        var client: std.http.Client = .{ .allocator = self.allocator };
-        defer client.deinit();
-
         // Create a file-backed writer for the response body.
         var write_buf: [8192]u8 = undefined;
         var file_writer = file.writer(&write_buf);
 
         // Use the high-level fetch API which handles redirects automatically.
-        const result = try client.fetch(.{
+        const result = try self.client.fetch(.{
             .location = .{ .url = url },
             .headers = headers,
             .extra_headers = extra_headers,
@@ -86,7 +87,8 @@ test "HttpClient fetch downloads a file" {
     });
     defer allocator.free(dest_path);
 
-    const client = HttpClient.init(allocator);
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
     try client.fetch(
         "https://httpbin.org/get",
         dest_path,
@@ -115,7 +117,8 @@ test "HttpClient fetchGhcr with auth header" {
     });
     defer allocator.free(dest_path);
 
-    const client = HttpClient.init(allocator);
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
     try client.fetchGhcr(
         "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:4b3576df4065747bf8c3b95c0a3eebc5f003a30819a645d9cc459bb06259c8ae",
         dest_path,


### PR DESCRIPTION
## Summary
- Reuse HTTP connections across multiple bottle downloads by lifting `std.http.Client` lifetime from per-request to per-`HttpClient` instance
- All callers (install, fetch, update) share a single connection pool, eliminating redundant TLS handshakes and TCP setup

Closes #24

## Test Plan
- [x] 102/102 unit tests pass
- [x] Clean build with no warnings