### PR TITLE
fix: use-after-free segfault in upgrade command

### DIFF
--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -79,7 +79,7 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
         if (installed_pv.order(index_pv) == .lt) {
             try to_upgrade.append(allocator, .{
                 .name = name,
-                .installed_version = installed_latest,
+                .installed_version = try allocator.dupe(u8, installed_latest),
                 .index_version = index_pv,
             });
         } else {
@@ -111,8 +111,8 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
             if (installed_pv.order(index_pv) == .lt) {
                 try to_upgrade.append(allocator, .{
-                    .name = formula.name,
-                    .installed_version = formula.latestVersion(),
+                    .name = try allocator.dupe(u8, formula.name),
+                    .installed_version = try allocator.dupe(u8, formula.latestVersion()),
                     .index_version = index_pv,
                 });
             }


### PR DESCRIPTION
## Summary
- Fix segfault in `bru upgrade` caused by use-after-free: the `to_upgrade` list stored pointers to cellar strings that were freed by `defer` before being accessed
- Duplicate the strings with `allocator.dupe()` so they outlive the scope

## Test plan
- [x] `zig build` compiles cleanly
- [x] `zig build test` passes
- [ ] Run `bru upgrade` on a machine with outdated packages — no segfault