### PR TITLE
fix: memory leak in upgrade command

### DIFF
--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -54,7 +54,13 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     // Collect outdated formulae to upgrade.
     var to_upgrade: std.ArrayList(OutdatedFormula) = .{};
-    defer to_upgrade.deinit(allocator);
+    defer {
+        for (to_upgrade.items) |item| {
+            allocator.free(item.name);
+            allocator.free(item.installed_version);
+        }
+        to_upgrade.deinit(allocator);
+    }
 
     if (formula_name) |name| {
         // Specific formula requested — check if installed and outdated.
@@ -86,7 +92,7 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
         if (installed_pv.order(index_pv) == .lt) {
             try to_upgrade.append(allocator, .{
-                .name = name,
+                .name = try allocator.dupe(u8, name),
                 .installed_version = try allocator.dupe(u8, installed_latest),
                 .index_version = index_pv,
             });


### PR DESCRIPTION
## Summary
- Free duped `name` and `installed_version` strings in `OutdatedFormula` when cleaning up the `to_upgrade` list
- Ensure the single-formula path also dupes `name` so cleanup is uniform across both code paths

## Test plan
- [x] `zig build` compiles cleanly
- [x] `zig build test` passes
- [ ] Run `bru upgrade` with GPA and verify no leaked memory addresses are reported