### PR TITLE
perf: content-addressable bottle cache with APFS clonefile

### DIFF
--- a/src/bottle.zig
+++ b/src/bottle.zig
@@ -3,6 +3,7 @@ const fs = std.fs;
 const mem = std.mem;
 const Allocator = mem.Allocator;
 const Config = @import("config.zig").Config;
+const clonefile_mod = @import("clonefile.zig");
 
 /// Pre-allocated pool of 1MB buffers for parallel file extraction.
 /// Main thread claims buffers to read tar file content into, then hands
@@ -180,6 +181,13 @@ fn createSymlink(dir: fs.Dir, link_name: []const u8, file_name: []const u8) !voi
     };
 }
 
+/// Check whether a directory exists at the given absolute path.
+fn dirExists(path: []const u8) bool {
+    var dir = fs.openDirAbsolute(path, .{}) catch return false;
+    dir.close();
+    return true;
+}
+
 /// Handles extraction and post-processing of Homebrew bottle archives.
 pub const Bottle = struct {
     allocator: Allocator,
@@ -301,6 +309,106 @@ pub const Bottle = struct {
             name,
             version,
         });
+    }
+
+    /// Extract a bottle with a two-tier extracted-keg cache.
+    ///
+    /// Fast path: if an extracted keg for `bottle_sha256` already exists in
+    /// `keg_cache_dir`, clone it straight into the cellar.
+    /// Slow path: extract via `pour`, then best-effort clone the result into
+    /// the cache for next time.
+    ///
+    /// Cache layout: `{keg_cache_dir}/{sha256}/{name}/{version}/...`
+    /// Caller owns the returned keg path string.
+    pub fn pourWithCache(
+        self: Bottle,
+        archive_path: []const u8,
+        name: []const u8,
+        version: []const u8,
+        bottle_sha256: []const u8,
+        keg_cache_dir: []const u8,
+    ) ![]const u8 {
+        // Build the cache source path: {keg_cache_dir}/{sha256}
+        const cache_sha_dir = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{
+            keg_cache_dir,
+            bottle_sha256,
+        });
+        defer self.allocator.free(cache_sha_dir);
+
+        // Build the full cache keg path: {keg_cache_dir}/{sha256}/{name}/{version}
+        const cache_keg_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}/{s}", .{
+            cache_sha_dir,
+            name,
+            version,
+        });
+        defer self.allocator.free(cache_keg_path);
+
+        // Build the cellar keg path: {cellar}/{name}/{version}
+        const keg_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}/{s}", .{
+            self.cellar,
+            name,
+            version,
+        });
+        errdefer self.allocator.free(keg_path);
+
+        // --- Fast path: cache hit ----------------------------------------
+        if (dirExists(cache_sha_dir)) {
+            // Ensure the cellar name directory exists ({cellar}/{name}).
+            const cellar_name_dir = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{
+                self.cellar,
+                name,
+            });
+            defer self.allocator.free(cellar_name_dir);
+
+            fs.makeDirAbsolute(self.cellar) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+            fs.makeDirAbsolute(cellar_name_dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+
+            // Clone from cache to cellar.
+            if (clonefile_mod.cloneTree(cache_keg_path, keg_path)) |_| {
+                return keg_path;
+            } else |_| {
+                // cloneTree failed — clean up any partial clone before
+                // falling through to slow path (pour needs a clean slate).
+                fs.deleteTreeAbsolute(keg_path) catch {};
+            }
+        }
+
+        // --- Slow path: extract normally ---------------------------------
+        // pour() allocates and returns its own keg path string. We already
+        // have keg_path with the same value, so free the duplicate from pour.
+        const pour_keg_path = try self.pour(archive_path, name, version);
+        self.allocator.free(pour_keg_path);
+
+        // Best-effort: populate the cache for next time.
+        // Create cache parent dirs: {keg_cache_dir}/{sha256}/{name}
+        const cache_name_dir = std.fmt.allocPrint(self.allocator, "{s}/{s}", .{
+            cache_sha_dir,
+            name,
+        }) catch return keg_path;
+        defer self.allocator.free(cache_name_dir);
+
+        fs.makeDirAbsolute(keg_cache_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return keg_path,
+        };
+        fs.makeDirAbsolute(cache_sha_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return keg_path,
+        };
+        fs.makeDirAbsolute(cache_name_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return keg_path,
+        };
+
+        _ = clonefile_mod.cloneTree(keg_path, cache_keg_path) catch return keg_path;
+
+        return keg_path;
     }
 
     /// Compute file mode from tar header mode (owner executable -> all executable).
@@ -777,5 +885,81 @@ test "pour handles files larger than buffer pool size" {
     const small = try tmp.dir.readFileAlloc(allocator, "cellar/bigpkg/2.0.0/bin/tool", 1024);
     defer allocator.free(small);
     try std.testing.expectEqualStrings("small file", small);
+}
+
+test "pourWithCache returns cached keg on second call" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Create a bottle structure: {name}/{version}/bin/tool
+    try tmp.dir.makePath("cachepkg/1.0.0/bin");
+    try tmp.dir.writeFile(.{
+        .sub_path = "cachepkg/1.0.0/bin/tool",
+        .data = "#!/bin/sh\necho cachepkg\n",
+    });
+
+    // Get absolute path for the tmp dir.
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp.dir.realpath(".", &path_buf);
+
+    // Create a tar.gz of the package directory.
+    const archive_name = "cachepkg-1.0.0.tar.gz";
+    const tar_result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "tar", "czf", archive_name, "cachepkg" },
+        .cwd_dir = tmp.dir,
+    });
+    allocator.free(tar_result.stdout);
+    allocator.free(tar_result.stderr);
+
+    // Set up "cellar" and "keg_cache" directories.
+    try tmp.dir.makeDir("cellar");
+    try tmp.dir.makeDir("keg_cache");
+    var cellar_buf: [fs.max_path_bytes]u8 = undefined;
+    const cellar_path = try tmp.dir.realpath("cellar", &cellar_buf);
+    var cache_buf: [fs.max_path_bytes]u8 = undefined;
+    const keg_cache_path = try tmp.dir.realpath("keg_cache", &cache_buf);
+
+    // Build the archive absolute path.
+    const archive_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmp_path, archive_name });
+    defer allocator.free(archive_path);
+
+    const bottle = Bottle{
+        .allocator = allocator,
+        .cellar = cellar_path,
+        .prefix = "/opt/homebrew",
+    };
+
+    const fake_sha = "abc123deadbeef";
+
+    // --- First call: slow path (extract + populate cache) ---
+    const keg_path1 = try bottle.pourWithCache(archive_path, "cachepkg", "1.0.0", fake_sha, keg_cache_path);
+    defer allocator.free(keg_path1);
+
+    // Verify the keg was extracted in the cellar.
+    const extracted1 = try tmp.dir.readFileAlloc(allocator, "cellar/cachepkg/1.0.0/bin/tool", 1024 * 1024);
+    defer allocator.free(extracted1);
+    try std.testing.expectEqualStrings("#!/bin/sh\necho cachepkg\n", extracted1);
+
+    // Verify the cache was populated.
+    const cache_tool_path = try std.fmt.allocPrint(allocator, "keg_cache/{s}/cachepkg/1.0.0/bin/tool", .{fake_sha});
+    defer allocator.free(cache_tool_path);
+    const cached = try tmp.dir.readFileAlloc(allocator, cache_tool_path, 1024 * 1024);
+    defer allocator.free(cached);
+    try std.testing.expectEqualStrings("#!/bin/sh\necho cachepkg\n", cached);
+
+    // --- Delete the cellar keg to prove the second call uses the cache ---
+    try tmp.dir.deleteTree("cellar/cachepkg");
+
+    // --- Second call: fast path (clone from cache) ---
+    const keg_path2 = try bottle.pourWithCache(archive_path, "cachepkg", "1.0.0", fake_sha, keg_cache_path);
+    defer allocator.free(keg_path2);
+
+    // Verify the keg was restored from cache.
+    const extracted2 = try tmp.dir.readFileAlloc(allocator, "cellar/cachepkg/1.0.0/bin/tool", 1024 * 1024);
+    defer allocator.free(extracted2);
+    try std.testing.expectEqualStrings("#!/bin/sh\necho cachepkg\n", extracted2);
 }
 

--- a/src/clonefile.zig
+++ b/src/clonefile.zig
@@ -1,0 +1,251 @@
+const std = @import("std");
+const fs = std.fs;
+const posix = std.posix;
+const builtin = @import("builtin");
+
+/// Clone a directory tree from `src_path` to `dst_path`.
+///
+/// On macOS, tries `clonefile()` first (instant on APFS — metadata-only copy).
+/// Apple recommends `copyfile(3)` for directory trees, but `clonefile()` works
+/// on APFS and is a single syscall with no overhead. If a future macOS version
+/// rejects directory clonefile, the recursive copy fallback handles it.
+///
+/// Falls back to a recursive copy when clonefile is unsupported (e.g. cross-device,
+/// non-APFS filesystem, or non-macOS platform).
+///
+/// Returns `true` if clonefile succeeded, `false` if the fallback copy was used.
+pub fn cloneTree(src_path: []const u8, dst_path: []const u8) !bool {
+    if (comptime builtin.os.tag == .macos) {
+        // macOS clonefile() syscall — not exposed by Zig's std library.
+        const c = struct {
+            extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: c_uint) c_int;
+        };
+        const CLONE_NOFOLLOW: c_uint = 0x0001;
+
+        // Build sentinel-terminated path buffers for the C call.
+        var src_buf: [fs.max_path_bytes:0]u8 = undefined;
+        var dst_buf: [fs.max_path_bytes:0]u8 = undefined;
+
+        if (src_path.len >= fs.max_path_bytes) return error.NameTooLong;
+        if (dst_path.len >= fs.max_path_bytes) return error.NameTooLong;
+
+        @memcpy(src_buf[0..src_path.len], src_path);
+        src_buf[src_path.len] = 0;
+
+        @memcpy(dst_buf[0..dst_path.len], dst_path);
+        dst_buf[dst_path.len] = 0;
+
+        const rc = c.clonefile(&src_buf, &dst_buf, CLONE_NOFOLLOW);
+        if (rc == 0) return true;
+
+        // clonefile() is a C library function: returns -1 on error and sets
+        // the C thread-local errno. Read it directly (not via posix.errno
+        // which is for Linux-style raw syscall return values).
+        const e: posix.E = @enumFromInt(std.c._errno().*);
+
+        switch (e) {
+            // Source does not exist.
+            .NOENT => return error.FileNotFound,
+            // Destination already exists.
+            .EXIST => return error.PathAlreadyExists,
+            // Filesystem doesn't support clonefile or cross-device: fall back.
+            .OPNOTSUPP, .XDEV => {},
+            // Any other error is unexpected — propagate it.
+            else => return error.ClonefileFailed,
+        }
+    }
+
+    // Fallback: recursive copy (also the only path on non-macOS).
+    try recursiveCopy(src_path, dst_path);
+    return false;
+}
+
+/// Recursively copy a directory tree, preserving symlinks and file permissions.
+fn recursiveCopy(src_path: []const u8, dst_path: []const u8) !void {
+    // Stat the source to determine its type (without following symlinks).
+    const src_stat = fs.cwd().statFile(src_path) catch |err| switch (err) {
+        error.FileNotFound => return error.FileNotFound,
+        else => return error.CopyFailed,
+    };
+
+    if (src_stat.kind == .directory) {
+        // Create the destination directory.
+        fs.makeDirAbsolute(dst_path) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return error.CopyFailed,
+        };
+
+        // Iterate source directory entries.
+        var src_dir = fs.openDirAbsolute(src_path, .{ .iterate = true }) catch return error.CopyFailed;
+        defer src_dir.close();
+
+        var iter = src_dir.iterate();
+        while (iter.next() catch return error.CopyFailed) |entry| {
+            var child_src_buf: [fs.max_path_bytes]u8 = undefined;
+            const child_src = std.fmt.bufPrint(&child_src_buf, "{s}/{s}", .{ src_path, entry.name }) catch
+                return error.NameTooLong;
+
+            var child_dst_buf: [fs.max_path_bytes]u8 = undefined;
+            const child_dst = std.fmt.bufPrint(&child_dst_buf, "{s}/{s}", .{ dst_path, entry.name }) catch
+                return error.NameTooLong;
+
+            switch (entry.kind) {
+                .directory => try recursiveCopy(child_src, child_dst),
+                .sym_link => try copySymlink(src_dir, entry.name, child_dst),
+                else => try copyRegularFile(src_path, entry.name, dst_path),
+            }
+        }
+    } else {
+        return error.CopyFailed;
+    }
+}
+
+/// Recreate a symlink: read the target from the source and create an identical
+/// symlink at the destination path.
+fn copySymlink(src_dir: fs.Dir, name: []const u8, dst_path: []const u8) !void {
+    var target_buf: [fs.max_path_bytes]u8 = undefined;
+    const target = src_dir.readLink(name, &target_buf) catch return error.CopyFailed;
+
+    // Extract the parent directory and basename from dst_path.
+    const dirname = std.fs.path.dirname(dst_path) orelse return error.CopyFailed;
+    const basename = std.fs.path.basename(dst_path);
+
+    var dir = fs.openDirAbsolute(dirname, .{}) catch return error.CopyFailed;
+    defer dir.close();
+
+    dir.symLink(target, basename, .{}) catch return error.CopyFailed;
+}
+
+/// Copy a regular file from src_dir/name to dst_dir/name, preserving permissions.
+fn copyRegularFile(src_dir_path: []const u8, name: []const u8, dst_dir_path: []const u8) !void {
+    var src_dir = fs.openDirAbsolute(src_dir_path, .{}) catch return error.CopyFailed;
+    defer src_dir.close();
+
+    var dst_dir = fs.openDirAbsolute(dst_dir_path, .{}) catch return error.CopyFailed;
+    defer dst_dir.close();
+
+    // copyFile with null override_mode preserves the source file's permissions.
+    dst_dir.copyFile(name, src_dir, name, .{}) catch return error.CopyFailed;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "cloneTree copies directory with files" {
+    // Create a source directory with files.
+    var tmp_src = std.testing.tmpDir(.{});
+    defer tmp_src.cleanup();
+
+    // Create some files.
+    {
+        var f = try tmp_src.dir.createFile("hello.txt", .{});
+        defer f.close();
+        var write_buf: [4096]u8 = undefined;
+        var w = f.writer(&write_buf);
+        try w.interface.writeAll("hello world");
+        try w.interface.flush();
+    }
+    try tmp_src.dir.makeDir("subdir");
+    {
+        var f = try tmp_src.dir.createFile("subdir/nested.txt", .{});
+        defer f.close();
+        var write_buf: [4096]u8 = undefined;
+        var w = f.writer(&write_buf);
+        try w.interface.writeAll("nested content");
+        try w.interface.flush();
+    }
+
+    // Get real paths.
+    var src_buf: [fs.max_path_bytes]u8 = undefined;
+    const src_path = try tmp_src.dir.realpath(".", &src_buf);
+
+    // Create a sibling destination path (in the same tmp area so clonefile should work).
+    var tmp_parent = std.testing.tmpDir(.{});
+    defer tmp_parent.cleanup();
+
+    var dst_buf: [fs.max_path_bytes]u8 = undefined;
+    const parent_path = try tmp_parent.dir.realpath(".", &dst_buf);
+
+    var dst_path_buf: [fs.max_path_bytes]u8 = undefined;
+    const dst_path = try std.fmt.bufPrint(&dst_path_buf, "{s}/clone_dest", .{parent_path});
+
+    const used_clonefile = try cloneTree(src_path, dst_path);
+    _ = used_clonefile; // Either path is fine — we verify contents below.
+
+    // Verify top-level file.
+    var dst_dir = try fs.openDirAbsolute(dst_path, .{});
+    defer dst_dir.close();
+
+    {
+        var f = try dst_dir.openFile("hello.txt", .{});
+        defer f.close();
+        var content_buf: [256]u8 = undefined;
+        const n = try f.readAll(&content_buf);
+        try std.testing.expectEqualStrings("hello world", content_buf[0..n]);
+    }
+
+    // Verify nested file.
+    {
+        var f = try dst_dir.openFile("subdir/nested.txt", .{});
+        defer f.close();
+        var content_buf: [256]u8 = undefined;
+        const n = try f.readAll(&content_buf);
+        try std.testing.expectEqualStrings("nested content", content_buf[0..n]);
+    }
+}
+
+test "cloneTree preserves symlinks" {
+    var tmp_src = std.testing.tmpDir(.{});
+    defer tmp_src.cleanup();
+
+    // Create a file and a symlink to it.
+    {
+        var f = try tmp_src.dir.createFile("target.txt", .{});
+        defer f.close();
+        var write_buf: [4096]u8 = undefined;
+        var w = f.writer(&write_buf);
+        try w.interface.writeAll("target content");
+        try w.interface.flush();
+    }
+    try tmp_src.dir.symLink("target.txt", "link.txt", .{});
+
+    var src_buf: [fs.max_path_bytes]u8 = undefined;
+    const src_path = try tmp_src.dir.realpath(".", &src_buf);
+
+    var tmp_parent = std.testing.tmpDir(.{});
+    defer tmp_parent.cleanup();
+
+    var parent_buf: [fs.max_path_bytes]u8 = undefined;
+    const parent_path = try tmp_parent.dir.realpath(".", &parent_buf);
+
+    var dst_path_buf: [fs.max_path_bytes]u8 = undefined;
+    const dst_path = try std.fmt.bufPrint(&dst_path_buf, "{s}/clone_dest", .{parent_path});
+
+    _ = try cloneTree(src_path, dst_path);
+
+    // Verify the symlink exists and points to the correct target.
+    var dst_dir = try fs.openDirAbsolute(dst_path, .{});
+    defer dst_dir.close();
+
+    var link_target_buf: [fs.max_path_bytes]u8 = undefined;
+    const link_target = try dst_dir.readLink("link.txt", &link_target_buf);
+    try std.testing.expectEqualStrings("target.txt", link_target);
+}
+
+test "cloneTree fails with FileNotFound when source doesn't exist" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var tmp_buf: [fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp.dir.realpath(".", &tmp_buf);
+
+    var src_buf: [fs.max_path_bytes]u8 = undefined;
+    const src_path = try std.fmt.bufPrint(&src_buf, "{s}/nonexistent_source", .{tmp_path});
+
+    var dst_buf: [fs.max_path_bytes]u8 = undefined;
+    const dst_path = try std.fmt.bufPrint(&dst_buf, "{s}/nonexistent_dest", .{tmp_path});
+
+    const result = cloneTree(src_path, dst_path);
+    try std.testing.expectError(error.FileNotFound, result);
+}

--- a/src/cmd/cleanup.zig
+++ b/src/cmd/cleanup.zig
@@ -31,6 +31,7 @@ pub fn cleanupCmd(allocator: Allocator, args: []const []const u8, config: Config
     }
 
     const out = Output.init(config.no_color);
+    const err_out = Output.initErr(config.no_color);
 
     // 2. Clean old versions from cellar.
     const cellar = Cellar.init(config.cellar);
@@ -59,7 +60,6 @@ pub fn cleanupCmd(allocator: Allocator, args: []const []const u8, config: Config
             } else {
                 out.print("Removing: {s}\n", .{keg_path});
                 fs.deleteTreeAbsolute(keg_path) catch |err| {
-                    const err_out = Output.initErr(config.no_color);
                     err_out.err("Could not remove {s}: {s}", .{ keg_path, @errorName(err) });
                     continue;
                 };
@@ -68,58 +68,131 @@ pub fn cleanupCmd(allocator: Allocator, args: []const []const u8, config: Config
         }
     }
 
-    // 3. Clean old downloads from cache.
-    var downloads_removed: u32 = 0;
+    // 3. Clean old downloads, blobs, and keg cache entries.
     const max_age_secs: i64 = @as(i64, prune_days) * 86400;
 
-    var cache_path_buf: [fs.max_path_bytes]u8 = undefined;
-    const downloads_path = std.fmt.bufPrint(&cache_path_buf, "{s}/downloads", .{config.cache}) catch {
-        out.print("Cleaned {d} old downloads.\n", .{downloads_removed});
-        return;
-    };
+    // 3a. Legacy downloads (files in {cache}/downloads/).
+    const downloads_removed = pruneOldFiles(config.cache, "downloads", max_age_secs, dry_run, out, err_out);
 
-    var downloads_dir = fs.openDirAbsolute(downloads_path, .{ .iterate = true }) catch {
-        // Downloads directory doesn't exist or can't be opened — nothing to prune.
-        if (versions_removed > 0) {
-            out.section("Cleanup complete");
-        }
-        out.print("Cleaned {d} old downloads.\n", .{downloads_removed});
-        return;
-    };
-    defer downloads_dir.close();
+    // 3b. Content-addressable blobs (files in {cache}/blobs/).
+    const blobs_removed = pruneOldFiles(config.cache, "blobs", max_age_secs, dry_run, out, err_out);
 
-    var iter = downloads_dir.iterate();
-    while (iter.next() catch null) |entry| {
+    // 3c. Extracted keg cache (directories in {cache}/kegs/).
+    const kegs_removed = pruneOldDirs(config.cache, "kegs", max_age_secs, dry_run, out, err_out);
+
+    // 4. Print summary.
+    const total_cache = downloads_removed + blobs_removed + kegs_removed;
+    if (versions_removed > 0 or total_cache > 0) {
+        out.section("Cleanup complete");
+    }
+    if (versions_removed > 0) {
+        out.print("Removed {d} old version{s}.\n", .{
+            versions_removed,
+            if (versions_removed == 1) "" else "s",
+        });
+    }
+    if (total_cache > 0) {
+        out.print("Removed {d} cached file{s}.\n", .{
+            total_cache,
+            if (total_cache == 1) "" else "s",
+        });
+    }
+    if (versions_removed == 0 and total_cache == 0) {
+        out.print("Already clean.\n", .{});
+    }
+}
+
+/// Prune files older than max_age_secs from {cache}/{subdir}/.
+fn pruneOldFiles(
+    cache: []const u8,
+    subdir: []const u8,
+    max_age_secs: i64,
+    dry_run: bool,
+    out: Output,
+    err_out: Output,
+) u32 {
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cache, subdir }) catch return 0;
+
+    var dir = fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch return 0;
+    defer dir.close();
+
+    var removed: u32 = 0;
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
         if (entry.kind != .file) continue;
 
-        const file = downloads_dir.openFile(entry.name, .{}) catch continue;
+        const file = dir.openFile(entry.name, .{}) catch continue;
         defer file.close();
 
         const stat = file.stat() catch continue;
         const mtime_secs: i64 = @intCast(@divFloor(stat.mtime, std.time.ns_per_s));
-        const now = std.time.timestamp();
-        const age = now - mtime_secs;
+        const age = std.time.timestamp() - mtime_secs;
 
         if (age > max_age_secs) {
             if (dry_run) {
-                out.print("Would remove: {s}/{s}\n", .{ downloads_path, entry.name });
+                out.print("Would remove: {s}/{s}\n", .{ dir_path, entry.name });
             } else {
-                out.print("Removing: {s}/{s}\n", .{ downloads_path, entry.name });
-                downloads_dir.deleteFile(entry.name) catch |err| {
-                    const err_out = Output.initErr(config.no_color);
-                    err_out.err("Could not remove {s}/{s}: {s}", .{ downloads_path, entry.name, @errorName(err) });
+                out.print("Removing: {s}/{s}\n", .{ dir_path, entry.name });
+                dir.deleteFile(entry.name) catch |err| {
+                    err_out.err("Could not remove {s}/{s}: {s}", .{ dir_path, entry.name, @errorName(err) });
                     continue;
                 };
             }
-            downloads_removed += 1;
+            removed += 1;
         }
     }
+    return removed;
+}
 
-    // 4. Print summary.
-    if (versions_removed > 0 or downloads_removed > 0) {
-        out.section("Cleanup complete");
+/// Prune directories older than max_age_secs from {cache}/{subdir}/.
+fn pruneOldDirs(
+    cache: []const u8,
+    subdir: []const u8,
+    max_age_secs: i64,
+    dry_run: bool,
+    out: Output,
+    err_out: Output,
+) u32 {
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cache, subdir }) catch return 0;
+
+    var dir = fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch return 0;
+    defer dir.close();
+
+    var removed: u32 = 0;
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .directory) continue;
+
+        // Check mtime of the directory itself.
+        var sub_dir = dir.openDir(entry.name, .{}) catch continue;
+        const stat = sub_dir.stat() catch {
+            sub_dir.close();
+            continue;
+        };
+        sub_dir.close();
+
+        const mtime_secs: i64 = @intCast(@divFloor(stat.mtime, std.time.ns_per_s));
+        const age = std.time.timestamp() - mtime_secs;
+
+        if (age > max_age_secs) {
+            var full_buf: [fs.max_path_bytes]u8 = undefined;
+            const full_path = std.fmt.bufPrint(&full_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
+
+            if (dry_run) {
+                out.print("Would remove: {s}\n", .{full_path});
+            } else {
+                out.print("Removing: {s}\n", .{full_path});
+                fs.deleteTreeAbsolute(full_path) catch |err| {
+                    err_out.err("Could not remove {s}: {s}", .{ full_path, @errorName(err) });
+                    continue;
+                };
+            }
+            removed += 1;
+        }
     }
-    out.print("Cleaned {d} old downloads.\n", .{downloads_removed});
+    return removed;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -155,8 +155,11 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     var bottle = Bottle.init(allocator, config);
 
+    const keg_cache_dir = try std.fmt.allocPrint(allocator, "{s}/kegs", .{config.cache});
+    defer allocator.free(keg_cache_dir);
+
     var extract_timer = Timer.start(&trace, "extract");
-    const keg_path = try bottle.pour(archive_path, name, version);
+    const keg_path = try bottle.pourWithCache(archive_path, name, version, bottle_sha256, keg_cache_dir);
     extract_timer.stop();
     defer allocator.free(keg_path);
 

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -243,15 +243,17 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
         // 3. Extract new bottle into cellar.
         out.print("Pouring {s} {s}...\n", .{ item.name, version });
-        var bottle = Bottle.init(allocator, config);
-        const keg_path = bottle.pour(archive_path, item.name, version) catch |err| {
+        var bottle_inst = Bottle.init(allocator, config);
+        const keg_cache_dir = std.fmt.allocPrint(allocator, "{s}/kegs", .{config.cache}) catch continue;
+        defer allocator.free(keg_cache_dir);
+        const keg_path = bottle_inst.pourWithCache(archive_path, item.name, version, bottle_sha256, keg_cache_dir) catch |err| {
             err_out.err("Extraction failed for {s}: {s}", .{ item.name, @errorName(err) });
             continue;
         };
         defer allocator.free(keg_path);
 
         // 4. Replace placeholders.
-        bottle.replacePlaceholders(keg_path) catch |err| {
+        bottle_inst.replacePlaceholders(keg_path) catch |err| {
             err_out.err("Placeholder replacement failed for {s}: {s}", .{ item.name, @errorName(err) });
         };
 

--- a/src/download.zig
+++ b/src/download.zig
@@ -23,37 +23,66 @@ pub const Download = struct {
         return std.fmt.allocPrint(self.allocator, "{s}/downloads/{s}--{s}", .{ self.cache_dir, hex, name });
     }
 
-    /// Download a bottle, using cache if available and checksum matches.
-    /// Returns the cache path (caller owns the string).
-    pub fn fetchBottle(self: Download, url: []const u8, name: []const u8, expected_sha256: []const u8) ![]const u8 {
-        const path = try self.cachePath(url, name);
-        errdefer self.allocator.free(path);
+    /// Return the blob store path for a content-addressed file.
+    /// Format: {cache_dir}/blobs/{sha256}.tar.gz
+    pub fn blobPath(self: Download, sha256: []const u8) ![]const u8 {
+        return std.fmt.allocPrint(self.allocator, "{s}/blobs/{s}.tar.gz", .{ self.cache_dir, sha256 });
+    }
 
-        // Check if cached file exists and checksum matches.
-        if (verifySha256(path, expected_sha256) catch false) {
-            return path;
+    /// Download a bottle, using cache if available and checksum matches.
+    /// Returns the blob path (caller owns the string).
+    pub fn fetchBottle(self: Download, url: []const u8, name: []const u8, expected_sha256: []const u8) ![]const u8 {
+        const blob = try self.blobPath(expected_sha256);
+        errdefer self.allocator.free(blob);
+
+        // 1. Check blob store first (content-addressed by SHA256).
+        if (verifySha256(blob, expected_sha256) catch false) {
+            return blob;
         }
 
-        // Ensure the downloads directory exists.
-        const downloads_dir = try std.fmt.allocPrint(self.allocator, "{s}/downloads", .{self.cache_dir});
-        defer self.allocator.free(downloads_dir);
-        std.fs.cwd().makePath(downloads_dir) catch |err| switch (err) {
+        // 2. Check legacy cache path for backward compatibility.
+        const legacy = try self.cachePath(url, name);
+        defer self.allocator.free(legacy);
+
+        if (verifySha256(legacy, expected_sha256) catch false) {
+            // Ensure the blobs directory exists.
+            const blobs_dir = try std.fmt.allocPrint(self.allocator, "{s}/blobs", .{self.cache_dir});
+            defer self.allocator.free(blobs_dir);
+            std.fs.cwd().makePath(blobs_dir) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => return err,
+            };
+
+            // 3. Migrate: rename legacy file to blob store.
+            std.fs.cwd().rename(legacy, blob) catch {
+                // If rename fails (e.g. cross-device), copy instead.
+                const cwd = std.fs.cwd();
+                cwd.copyFile(legacy, cwd, blob, .{}) catch return error.MigrationFailed;
+                std.fs.cwd().deleteFile(legacy) catch {};
+            };
+            return blob;
+        }
+
+        // 4. Not found anywhere — ensure the blobs directory exists, then download.
+        const blobs_dir = try std.fmt.allocPrint(self.allocator, "{s}/blobs", .{self.cache_dir});
+        defer self.allocator.free(blobs_dir);
+        std.fs.cwd().makePath(blobs_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
 
         // Download via HttpClient.fetchGhcr.
-        try self.http_client.fetchGhcr(url, path);
+        try self.http_client.fetchGhcr(url, blob);
 
-        // Verify checksum after download.
-        const valid = try verifySha256(path, expected_sha256);
+        // 5. Verify checksum after download.
+        const valid = try verifySha256(blob, expected_sha256);
         if (!valid) {
             // Delete the bad file and return error.
-            std.fs.cwd().deleteFile(path) catch {};
+            std.fs.cwd().deleteFile(blob) catch {};
             return error.ChecksumMismatch;
         }
 
-        return path;
+        return blob;
     }
 };
 
@@ -122,6 +151,32 @@ test "cachePath produces deterministic path" {
 
     // Path should end with "--myformula".
     try std.testing.expect(std.mem.endsWith(u8, path1, "--myformula"));
+}
+
+test "blobPath produces content-addressed path" {
+    const allocator = std.testing.allocator;
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
+    const dl = Download.init(allocator, "/tmp/bru-test-cache", &client);
+
+    const sha = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
+    const path = try dl.blobPath(sha);
+    defer allocator.free(path);
+
+    // Path should be {cache_dir}/blobs/{sha256}.tar.gz
+    try std.testing.expectEqualStrings("/tmp/bru-test-cache/blobs/abc123def456abc123def456abc123def456abc123def456abc123def456abcd.tar.gz", path);
+
+    // Path should contain "blobs/".
+    try std.testing.expect(std.mem.indexOf(u8, path, "blobs/") != null);
+
+    // Path should end with ".tar.gz".
+    try std.testing.expect(std.mem.endsWith(u8, path, ".tar.gz"));
+
+    // Different SHA should produce a different path.
+    const sha2 = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    const path2 = try dl.blobPath(sha2);
+    defer allocator.free(path2);
+    try std.testing.expect(!std.mem.eql(u8, path, path2));
 }
 
 test "verifySha256 on known content" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -110,4 +110,5 @@ test {
     _ = @import("json_helpers.zig");
     _ = @import("fuzzy.zig");
     _ = @import("timer.zig");
+    _ = @import("clonefile.zig");
 }


### PR DESCRIPTION
## Summary
- Adds two-tier bottle cache: downloaded bottles stored by SHA256 in `blobs/`, extracted kegs cached in `kegs/`
- Uses macOS `clonefile()` syscall for near-instant warm installs (skips both download and extraction)
- Falls back to recursive copy on non-APFS filesystems
- Extends `bru cleanup` to prune blob and keg cache directories

## Test plan
- [x] All unit tests pass (`zig build test`)
- [x] ReleaseFast build succeeds
- [ ] `bru install <pkg> --timing` then uninstall and reinstall to verify warm cache speedup