### PR TITLE
perf: arena allocator for zero-cost cleanup in release builds

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,14 +1,29 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Config = @import("config.zig").Config;
 const dispatch = @import("dispatch.zig");
 const fallback = @import("fallback.zig");
 const help = @import("help.zig");
 
 pub fn main() !void {
-    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa_instance.deinit();
-    const allocator = gpa_instance.allocator();
+    // Release builds: arena allocator with thread-safe wrapper. Every alloc()
+    // is a pointer bump; every free() is a no-op. The process exits after one
+    // command, so OS reclamation handles cleanup — "the missile knows when it
+    // hits."
+    //
+    // Debug builds: GPA for leak detection during development.
+    if (builtin.mode == .Debug) {
+        var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+        defer _ = gpa_instance.deinit();
+        try run(gpa_instance.allocator());
+    } else {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        var ts = std.heap.ThreadSafeAllocator{ .child_allocator = arena.allocator() };
+        try run(ts.allocator());
+    }
+}
 
+fn run(allocator: std.mem.Allocator) !void {
     var cfg = try Config.load(allocator);
     defer cfg.deinit();
 


### PR DESCRIPTION
## Summary
- Replace GPA with ArenaAllocator (+ ThreadSafeAllocator for thread safety) in release builds
- Every `alloc()` becomes a pointer bump; every `free()` becomes a no-op — process exit is the garbage collector
- GPA retained in debug builds for leak detection

## Benchmarks (ReleaseFast, 100 iterations)

| Command | GPA | Arena | Improvement |
|---|---|---|---|
| `bru list` | 0.71s | 0.61s | **14% faster** |
| `bru outdated` | 0.68s | 0.61s | **10% faster** |
| `bru info bat` | 0.27s | 0.26s | ~4% |

Memory (`bru outdated`): RSS -5%, page reclaims **-40%** (678 → 403).

## Test plan
- [x] `zig build` (debug) compiles
- [x] `zig build -Doptimize=ReleaseFast` compiles
- [x] All unit tests pass
- [x] Smoke tested `bru --version`, `bru list`, `bru info`, `bru outdated`, `bru search`, `bru deps`