### PR TITLE
feat: native cask install with binary artifact extraction

### DIFF
--- a/src/cask.zig
+++ b/src/cask.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
+const HttpClient = @import("http.zig").HttpClient;
 
 /// Parsed representation of a single Homebrew cask from the API JSON.
 pub const CaskInfo = struct {
@@ -139,6 +140,259 @@ fn jsonBool(obj: std.json.ObjectMap, key: []const u8) ?bool {
 }
 
 // ---------------------------------------------------------------------------
+// Per-cask API types and parsing (for cask install)
+// ---------------------------------------------------------------------------
+
+/// A binary artifact extracted from a cask's artifacts array.
+pub const BinaryArtifact = struct {
+    source: []const u8, // path inside the archive, e.g., "firefox.wrapper.sh"
+    target: []const u8, // symlink name for bin/, e.g., "firefox"
+};
+
+/// Resolved metadata for installing a single cask, fetched from per-cask API.
+pub const ResolvedCask = struct {
+    token: []const u8,
+    version: []const u8,
+    url: []const u8,
+    sha256: []const u8,
+    name: []const u8,
+    binaries: []BinaryArtifact,
+};
+
+/// Platform tags to try when resolving cask variations, in priority order.
+/// Tries the most specific first (arch + OS version), then falls back to
+/// less specific tags. The first match wins.
+fn platformVariationTags() []const []const u8 {
+    const arch = @import("builtin").target.cpu.arch;
+
+    if (arch == .aarch64) {
+        return &.{
+            "arm64_tahoe",
+            "arm64_sequoia",
+            "arm64_sonoma",
+            "arm64_ventura",
+            "arm64_monterey",
+            "arm64_big_sur",
+        };
+    }
+    return &.{
+        "tahoe",
+        "sequoia",
+        "sonoma",
+        "ventura",
+        "monterey",
+        "big_sur",
+    };
+}
+
+/// Fetch and resolve a cask from the per-cask API.
+/// Returns a ResolvedCask with platform-resolved URL/SHA256 and binary artifacts.
+/// All strings in the result are owned by the provided allocator.
+pub fn fetchAndResolveCask(allocator: Allocator, http_client: *HttpClient, token: []const u8) !ResolvedCask {
+    // Build API URL: https://formulae.brew.sh/api/cask/{token}.json
+    const api_url = try std.fmt.allocPrint(allocator, "https://formulae.brew.sh/api/cask/{s}.json", .{token});
+    defer allocator.free(api_url);
+
+    // Fetch JSON into memory.
+    const json_bytes = try http_client.fetchToMemory(allocator, api_url);
+    defer allocator.free(json_bytes);
+
+    return try parseResolvedCask(allocator, json_bytes);
+}
+
+/// Parse a per-cask API JSON response into a ResolvedCask.
+pub fn parseResolvedCask(allocator: Allocator, json_bytes: []const u8) !ResolvedCask {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidJson,
+    };
+
+    const result_token = try allocator.dupe(u8, jsonStr(obj, "token") orelse return error.MissingField);
+    errdefer allocator.free(result_token);
+
+    // Start with top-level url/sha256/version, then override from variations.
+    var url = try allocator.dupe(u8, jsonStr(obj, "url") orelse "");
+    errdefer allocator.free(url);
+
+    var sha256 = try allocator.dupe(u8, jsonStr(obj, "sha256") orelse "");
+    errdefer allocator.free(sha256);
+
+    var version = try allocator.dupe(u8, jsonStr(obj, "version") orelse "");
+    errdefer allocator.free(version);
+
+    // Check variations for platform-specific overrides.
+    // Allocate new values before freeing old ones to avoid double-free on OOM.
+    if (obj.get("variations")) |var_val| {
+        if (asObject(var_val)) |variations| {
+            const tags = platformVariationTags();
+            for (tags) |tag| {
+                if (variations.get(tag)) |tag_val| {
+                    if (asObject(tag_val)) |tag_obj| {
+                        if (jsonStr(tag_obj, "url")) |v_url| {
+                            const new_url = try allocator.dupe(u8, v_url);
+                            allocator.free(url);
+                            url = new_url;
+                        }
+                        if (jsonStr(tag_obj, "sha256")) |v_sha| {
+                            const new_sha = try allocator.dupe(u8, v_sha);
+                            allocator.free(sha256);
+                            sha256 = new_sha;
+                        }
+                        if (jsonStr(tag_obj, "version")) |v_ver| {
+                            const new_ver = try allocator.dupe(u8, v_ver);
+                            allocator.free(version);
+                            version = new_ver;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Parse name (first element of name array).
+    const result_name = blk: {
+        const name_val = obj.get("name") orelse break :blk try allocator.dupe(u8, "");
+        const name_arr = switch (name_val) {
+            .array => |a| a,
+            else => break :blk try allocator.dupe(u8, ""),
+        };
+        if (name_arr.items.len == 0) break :blk try allocator.dupe(u8, "");
+        const first = switch (name_arr.items[0]) {
+            .string => |s| s,
+            else => break :blk try allocator.dupe(u8, ""),
+        };
+        break :blk try allocator.dupe(u8, first);
+    };
+    errdefer allocator.free(result_name);
+
+    // Parse binary artifacts from the artifacts array.
+    const binaries = try parseBinaryArtifacts(allocator, obj);
+
+    return ResolvedCask{
+        .token = result_token,
+        .version = version,
+        .url = url,
+        .sha256 = sha256,
+        .name = result_name,
+        .binaries = binaries,
+    };
+}
+
+/// Parse binary artifacts from a cask's artifacts array.
+/// Binary artifacts come in two forms:
+///   - ["path/to/binary"]              -> source=path, target=basename
+///   - ["path/to/binary", {target: "name"}] -> source=path, target=name
+fn parseBinaryArtifacts(allocator: Allocator, obj: std.json.ObjectMap) ![]BinaryArtifact {
+    const artifacts_val = obj.get("artifacts") orelse return try allocator.alloc(BinaryArtifact, 0);
+    const artifacts_arr = switch (artifacts_val) {
+        .array => |a| a,
+        else => return try allocator.alloc(BinaryArtifact, 0),
+    };
+
+    var result = std.ArrayList(BinaryArtifact){};
+    errdefer {
+        for (result.items) |b| {
+            allocator.free(b.source);
+            allocator.free(b.target);
+        }
+        result.deinit(allocator);
+    }
+
+    for (artifacts_arr.items) |artifact_val| {
+        const artifact_obj = switch (artifact_val) {
+            .object => |o| o,
+            else => continue,
+        };
+
+        // Look for "binary" key.
+        const binary_val = artifact_obj.get("binary") orelse continue;
+        const binary_arr = switch (binary_val) {
+            .array => |a| a,
+            else => continue,
+        };
+
+        if (binary_arr.items.len == 0) continue;
+
+        // First element is the source path (string).
+        const source_raw = switch (binary_arr.items[0]) {
+            .string => |s| s,
+            else => continue,
+        };
+
+        // Strip $HOMEBREW_PREFIX/Caskroom/... prefix and $APPDIR/ prefix from source.
+        const source_clean = cleanArtifactPath(source_raw);
+
+        const source = try allocator.dupe(u8, source_clean);
+        errdefer allocator.free(source);
+
+        // Second element (if present and an object) has {target: "name"}.
+        const target = blk: {
+            if (binary_arr.items.len > 1) {
+                if (asObject(binary_arr.items[1])) |target_obj| {
+                    if (jsonStr(target_obj, "target")) |t| {
+                        break :blk try allocator.dupe(u8, t);
+                    }
+                }
+            }
+            // Default target: basename of source.
+            break :blk try allocator.dupe(u8, std.fs.path.basename(source_clean));
+        };
+
+        try result.append(allocator, .{ .source = source, .target = target });
+    }
+
+    return try result.toOwnedSlice(allocator);
+}
+
+/// Strip known prefixes from cask binary artifact paths.
+/// Removes "$HOMEBREW_PREFIX/Caskroom/{token}/{version}/" and "$APPDIR/" prefixes.
+fn cleanArtifactPath(path: []const u8) []const u8 {
+    // Strip $APPDIR/ prefix.
+    if (mem.startsWith(u8, path, "$APPDIR/")) {
+        return path["$APPDIR/".len..];
+    }
+    // Strip $HOMEBREW_PREFIX/Caskroom/... prefix.
+    if (mem.startsWith(u8, path, "$HOMEBREW_PREFIX/Caskroom/")) {
+        // Find the third / after "Caskroom/" to skip {token}/{version}/
+        const after_caskroom = path["$HOMEBREW_PREFIX/Caskroom/".len..];
+        if (mem.indexOfScalar(u8, after_caskroom, '/')) |slash1| {
+            const after_token = after_caskroom[slash1 + 1 ..];
+            if (mem.indexOfScalar(u8, after_token, '/')) |slash2| {
+                return after_token[slash2 + 1 ..];
+            }
+        }
+    }
+    return path;
+}
+
+fn asObject(val: std.json.Value) ?std.json.ObjectMap {
+    return switch (val) {
+        .object => |o| o,
+        else => null,
+    };
+}
+
+/// Free a ResolvedCask and all its owned memory.
+pub fn freeResolvedCask(allocator: Allocator, c: ResolvedCask) void {
+    allocator.free(c.token);
+    allocator.free(c.version);
+    allocator.free(c.url);
+    allocator.free(c.sha256);
+    allocator.free(c.name);
+    for (c.binaries) |b| {
+        allocator.free(b.source);
+        allocator.free(b.target);
+    }
+    allocator.free(c.binaries);
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -211,4 +465,110 @@ test "parseCaskJson handles name array with multiple elements" {
     try std.testing.expectEqual(@as(usize, 1), casks.len);
     // Should take the first element of the name array
     try std.testing.expectEqualStrings("Microsoft Visual Studio Code", casks[0].name);
+}
+
+test "parseResolvedCask parses per-cask API response" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "firefox",
+        \\  "full_token": "firefox",
+        \\  "name": ["Mozilla Firefox"],
+        \\  "desc": "Web browser",
+        \\  "homepage": "https://www.mozilla.org/firefox/",
+        \\  "url": "https://example.com/firefox.dmg",
+        \\  "version": "136.0.4",
+        \\  "sha256": "abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+        \\  "variations": {},
+        \\  "artifacts": [
+        \\    {"app": ["Firefox.app"]},
+        \\    {"binary": ["$HOMEBREW_PREFIX/Caskroom/firefox/136.0.4/firefox.wrapper.sh", {"target": "firefox"}]},
+        \\    {"zap": [{"trash": ["~/Library/Firefox"]}]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCask(allocator, json_bytes);
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqualStrings("firefox", resolved.token);
+    try std.testing.expectEqualStrings("136.0.4", resolved.version);
+    try std.testing.expectEqualStrings("https://example.com/firefox.dmg", resolved.url);
+    try std.testing.expectEqualStrings("abc123def456abc123def456abc123def456abc123def456abc123def456abcd", resolved.sha256);
+    try std.testing.expectEqualStrings("Mozilla Firefox", resolved.name);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.binaries.len);
+    try std.testing.expectEqualStrings("firefox.wrapper.sh", resolved.binaries[0].source);
+    try std.testing.expectEqualStrings("firefox", resolved.binaries[0].target);
+}
+
+test "parseResolvedCask with APPDIR binary path" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "visual-studio-code",
+        \\  "name": ["VS Code"],
+        \\  "url": "https://example.com/vscode.zip",
+        \\  "version": "1.85.0",
+        \\  "sha256": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        \\  "variations": {},
+        \\  "artifacts": [
+        \\    {"app": ["Visual Studio Code.app"]},
+        \\    {"binary": ["$APPDIR/Visual Studio Code.app/Contents/Resources/app/bin/code"]},
+        \\    {"binary": ["$APPDIR/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCask(allocator, json_bytes);
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 2), resolved.binaries.len);
+    try std.testing.expectEqualStrings("Visual Studio Code.app/Contents/Resources/app/bin/code", resolved.binaries[0].source);
+    try std.testing.expectEqualStrings("code", resolved.binaries[0].target);
+    try std.testing.expectEqualStrings("Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel", resolved.binaries[1].source);
+    try std.testing.expectEqualStrings("code-tunnel", resolved.binaries[1].target);
+}
+
+test "parseResolvedCask with no binary artifacts" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "google-chrome",
+        \\  "name": ["Google Chrome"],
+        \\  "url": "https://example.com/chrome.dmg",
+        \\  "version": "120.0",
+        \\  "sha256": "no_check",
+        \\  "variations": {},
+        \\  "artifacts": [
+        \\    {"app": ["Google Chrome.app"]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCask(allocator, json_bytes);
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 0), resolved.binaries.len);
+}
+
+test "cleanArtifactPath strips APPDIR prefix" {
+    try std.testing.expectEqualStrings(
+        "Visual Studio Code.app/Contents/Resources/app/bin/code",
+        cleanArtifactPath("$APPDIR/Visual Studio Code.app/Contents/Resources/app/bin/code"),
+    );
+}
+
+test "cleanArtifactPath strips HOMEBREW_PREFIX/Caskroom prefix" {
+    try std.testing.expectEqualStrings(
+        "firefox.wrapper.sh",
+        cleanArtifactPath("$HOMEBREW_PREFIX/Caskroom/firefox/136.0.4/firefox.wrapper.sh"),
+    );
+}
+
+test "cleanArtifactPath preserves plain paths" {
+    try std.testing.expectEqualStrings("studio", cleanArtifactPath("studio"));
 }

--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -1,0 +1,272 @@
+const std = @import("std");
+const fs = std.fs;
+const mem = std.mem;
+const Allocator = mem.Allocator;
+const Config = @import("config.zig").Config;
+const HttpClient = @import("http.zig").HttpClient;
+const Download = @import("download.zig").Download;
+const Linker = @import("linker.zig").Linker;
+const Output = @import("output.zig").Output;
+const cask = @import("cask.zig");
+const ResolvedCask = cask.ResolvedCask;
+const BinaryArtifact = cask.BinaryArtifact;
+
+/// Install a cask: download archive, extract, stage binaries, and link.
+pub fn installCask(allocator: Allocator, config: Config, http_client: *HttpClient, resolved: ResolvedCask) !void {
+    const out = Output.init(config.no_color);
+    const err_out = Output.initErr(config.no_color);
+
+    // 1. Check if already installed.
+    var caskroom_check_buf: [fs.max_path_bytes]u8 = undefined;
+    const caskroom_check = std.fmt.bufPrint(&caskroom_check_buf, "{s}/{s}", .{ config.caskroom, resolved.token }) catch unreachable;
+    if (fs.openDirAbsolute(caskroom_check, .{})) |dir| {
+        var d = dir;
+        d.close();
+        out.warn("{s} is already installed.", .{resolved.token});
+        return;
+    } else |_| {}
+
+    // 2. Print section header.
+    const install_title = try std.fmt.allocPrint(allocator, "Installing {s} {s}", .{ resolved.name, resolved.version });
+    defer allocator.free(install_title);
+    out.section(install_title);
+
+    // 3. Download archive.
+    out.print("Downloading {s}...\n", .{resolved.token});
+    var dl = Download.init(allocator, config.cache, http_client);
+    const archive_path = try dl.fetchCask(resolved.url, resolved.sha256);
+    defer allocator.free(archive_path);
+
+    // 4. Create caskroom directory: {caskroom}/{token}/{version}/
+    const version_dir = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ config.caskroom, resolved.token, resolved.version });
+    defer allocator.free(version_dir);
+    try fs.cwd().makePath(version_dir);
+
+    // 5. Determine archive type and extract.
+    const ext = Download.urlExtension(resolved.url);
+    out.print("Extracting {s}...\n", .{resolved.token});
+
+    if (mem.eql(u8, ext, ".dmg")) {
+        try extractDmg(allocator, archive_path, version_dir);
+    } else if (mem.eql(u8, ext, ".zip")) {
+        try extractZip(allocator, archive_path, version_dir);
+    } else if (mem.eql(u8, ext, ".tar.gz") or mem.eql(u8, ext, ".tar.bz2") or mem.eql(u8, ext, ".tar.xz")) {
+        try extractTar(allocator, archive_path, version_dir);
+    } else if (mem.eql(u8, ext, ".pkg")) {
+        err_out.warn("PKG archives cannot be extracted for binary-only install.", .{});
+        err_out.print("Use: brew install --cask {s}\n", .{resolved.token});
+        return error.UnsupportedArchiveType;
+    } else {
+        err_out.err("Unsupported archive format: {s}", .{ext});
+        return error.UnsupportedArchiveType;
+    }
+
+    // 6. Stage binary artifacts.
+    if (resolved.binaries.len > 0) {
+        const bin_dir = try std.fmt.allocPrint(allocator, "{s}/bin", .{version_dir});
+        defer allocator.free(bin_dir);
+        try fs.cwd().makePath(bin_dir);
+
+        for (resolved.binaries) |binary| {
+            stageBinary(allocator, version_dir, bin_dir, binary) catch |stage_err| {
+                err_out.warn("Could not stage binary \"{s}\": {s}", .{ binary.target, @errorName(stage_err) });
+            };
+        }
+    }
+
+    // 7. Link into prefix.
+    var linker = Linker.init(allocator, config.prefix);
+    try linker.link(resolved.token, version_dir);
+
+    // 8. Print completion.
+    const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is installed", .{ resolved.name, resolved.version });
+    defer allocator.free(done_title);
+    out.section(done_title);
+}
+
+/// Extract a DMG archive by mounting it, copying contents, and unmounting.
+fn extractDmg(allocator: Allocator, dmg_path: []const u8, dest_dir: []const u8) !void {
+    // Create a temporary mount point.
+    const mount_point = try std.fmt.allocPrint(allocator, "/tmp/bru-dmg-{d}", .{std.time.nanoTimestamp()});
+    defer allocator.free(mount_point);
+    try fs.cwd().makePath(mount_point);
+    defer fs.cwd().deleteDir(mount_point) catch {};
+
+    // Mount the DMG.
+    {
+        const result = try std.process.Child.run(.{
+            .allocator = allocator,
+            .argv = &.{ "hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount_point, dmg_path },
+        });
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+        switch (result.term) {
+            .Exited => |code| if (code != 0) return error.DmgMountFailed,
+            else => return error.DmgMountFailed,
+        }
+    }
+
+    // Ensure we detach on exit.
+    defer detachDmg(allocator, mount_point);
+
+    // Copy contents from mount point to dest_dir using ditto (preserves metadata).
+    const src_slash = try std.fmt.allocPrint(allocator, "{s}/.", .{mount_point});
+    defer allocator.free(src_slash);
+
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "ditto", src_slash, dest_dir },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return error.DmgCopyFailed,
+        else => return error.DmgCopyFailed,
+    }
+}
+
+/// Detach a DMG mount point, ignoring errors.
+fn detachDmg(allocator: Allocator, mount_point: []const u8) void {
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "hdiutil", "detach", mount_point, "-force" },
+    }) catch return;
+    allocator.free(result.stdout);
+    allocator.free(result.stderr);
+}
+
+/// Extract a ZIP archive using unzip.
+fn extractZip(allocator: Allocator, zip_path: []const u8, dest_dir: []const u8) !void {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "unzip", "-o", "-q", zip_path, "-d", dest_dir },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return error.UnzipFailed,
+        else => return error.UnzipFailed,
+    }
+}
+
+/// Extract a tar archive (tar.gz, tar.bz2, tar.xz) using tar.
+fn extractTar(allocator: Allocator, tar_path: []const u8, dest_dir: []const u8) !void {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "tar", "xf", tar_path, "-C", dest_dir },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return error.TarFailed,
+        else => return error.TarFailed,
+    }
+}
+
+/// Stage a single binary artifact: find it in the extracted tree and
+/// symlink it into the cask's bin/ directory.
+fn stageBinary(allocator: Allocator, version_dir: []const u8, bin_dir: []const u8, binary: BinaryArtifact) !void {
+    // Build the full source path within the extracted tree.
+    const source_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, binary.source });
+    defer allocator.free(source_path);
+
+    // Build the target path in bin/.
+    const target_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ bin_dir, binary.target });
+    defer allocator.free(target_path);
+
+    // Verify the source exists.
+    fs.cwd().access(source_path, .{}) catch {
+        return error.BinaryNotFound;
+    };
+
+    // Ensure the source is executable.
+    const source_file = try fs.cwd().openFile(source_path, .{});
+    defer source_file.close();
+    const stat = try source_file.stat();
+
+    // Add execute permissions if not already set.
+    const mode = stat.mode;
+    const new_mode = mode | 0o111;
+    if (new_mode != mode) {
+        try source_file.chmod(new_mode);
+    }
+
+    // Remove existing symlink/file at target.
+    fs.deleteFileAbsolute(target_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+
+    // Create symlink: bin/{target} -> {version_dir}/{source}
+    try fs.symLinkAbsolute(source_path, target_path, .{});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "cask_install compiles" {
+    // Verify this module compiles and links correctly.
+    _ = installCask;
+    _ = extractZip;
+    _ = extractTar;
+}
+
+test "stageBinary creates symlink and sets executable" {
+    const allocator = std.testing.allocator;
+
+    // Create fake version directory with a binary.
+    var tmp_version = std.testing.tmpDir(.{});
+    defer tmp_version.cleanup();
+
+    // Create a fake binary file.
+    const f = try tmp_version.dir.createFile("my-tool.sh", .{});
+    try f.writeAll("#!/bin/sh\necho hello\n");
+    f.close();
+
+    // Create bin/ directory.
+    try tmp_version.dir.makeDir("bin");
+
+    // Get real paths.
+    var version_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try tmp_version.dir.realpath(".", &version_buf);
+
+    var bin_buf: [fs.max_path_bytes]u8 = undefined;
+    const bin_dir = try tmp_version.dir.realpath("bin", &bin_buf);
+
+    const binary = BinaryArtifact{ .source = "my-tool.sh", .target = "mytool" };
+    try stageBinary(allocator, version_dir, bin_dir, binary);
+
+    // Verify the symlink exists and points to the source.
+    var link_path_buf: [fs.max_path_bytes]u8 = undefined;
+    const link_path = try std.fmt.bufPrint(&link_path_buf, "{s}/mytool", .{bin_dir});
+
+    var read_buf: [fs.max_path_bytes]u8 = undefined;
+    const target = try fs.readLinkAbsolute(link_path, &read_buf);
+
+    var expected_buf: [fs.max_path_bytes]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&expected_buf, "{s}/my-tool.sh", .{version_dir});
+    try std.testing.expectEqualStrings(expected, target);
+
+    // Verify the source is executable.
+    const stat = try tmp_version.dir.statFile("my-tool.sh");
+    try std.testing.expect((stat.mode & 0o111) != 0);
+}
+
+test "stageBinary returns error for missing binary" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("bin");
+
+    var version_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try tmp.dir.realpath(".", &version_buf);
+
+    var bin_buf: [fs.max_path_bytes]u8 = undefined;
+    const bin_dir = try tmp.dir.realpath("bin", &bin_buf);
+
+    const binary = BinaryArtifact{ .source = "nonexistent", .target = "mytool" };
+    const result = stageBinary(allocator, version_dir, bin_dir, binary);
+    try std.testing.expectError(error.BinaryNotFound, result);
+}

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Config = @import("../config.zig").Config;
 const Index = @import("../index.zig").Index;
+const CaskIndex = @import("../cask_index.zig").CaskIndex;
 const Cellar = @import("../cellar.zig").Cellar;
 const download = @import("../download.zig");
 const Download = download.Download;
@@ -17,34 +18,50 @@ const Timer = timer_mod.Timer;
 const Trace = timer_mod.Trace;
 const HttpClient = @import("../http.zig").HttpClient;
 const batch_download = @import("../batch_download.zig");
+const cask_mod = @import("../cask.zig");
+const cask_install = @import("../cask_install.zig");
 
-/// Install a formula from a pre-built bottle.
+/// Install a formula or cask.
 ///
 /// Usage: bru install <formula>
+///        bru install --cask <cask>
 ///
-/// Looks up the formula in the binary index, downloads the bottle from GHCR,
-/// extracts it into the cellar, replaces placeholders, writes an install
-/// receipt, and links the keg into the prefix.
+/// For formulae: downloads the bottle from GHCR, extracts into cellar, links.
+/// For casks: downloads archive from vendor URL, extracts into caskroom,
+/// stages binary artifacts, and links binaries into prefix.
 pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
-    // 1. Parse args — find first non-flag argument as formula name.
-    var formula_name: ?[]const u8 = null;
+    // 1. Parse args — find first non-flag argument and check for --cask flag.
+    var pkg_name: ?[]const u8 = null;
+    var is_cask = false;
     for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
+            is_cask = true;
+            continue;
+        }
         if (arg.len > 0 and arg[0] == '-') continue;
-        formula_name = arg;
-        break;
+        if (pkg_name == null) pkg_name = arg;
     }
 
-    const name = formula_name orelse {
+    const name = pkg_name orelse {
         var err_buf: [4096]u8 = undefined;
         var ew = std.fs.File.stderr().writer(&err_buf);
         const stderr = &ew.interface;
-        try stderr.print("Usage: bru install <formula>\n", .{});
+        if (is_cask) {
+            try stderr.print("Usage: bru install --cask <cask>\n", .{});
+        } else {
+            try stderr.print("Usage: bru install <formula>\n", .{});
+        }
         try stderr.flush();
         std.process.exit(1);
     };
 
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
+
+    // Handle --cask installs.
+    if (is_cask) {
+        return installCaskCmd(allocator, name, config, out, err_out);
+    }
 
     // Initialize trace for timing/profiling.
     var trace = Trace.init(allocator, config.timing);
@@ -67,6 +84,17 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     const entry = idx.lookup(name) orelse {
         err_out.err("No available formula with the name \"{s}\".", .{name});
+
+        // Check if this is a cask and suggest --cask flag.
+        const cask_idx = CaskIndex.loadOrBuild(allocator, config.cache) catch null;
+        if (cask_idx) |ci| {
+            var cask_index = ci;
+            if (cask_index.lookup(name) != null) {
+                err_out.print("Did you mean the cask \"{s}\"? Try: bru install --cask {s}\n", .{ name, name });
+                std.process.exit(1);
+            }
+        }
+
         const similar = fuzzy.findSimilar(&idx, allocator, name, 3, 3) catch &.{};
         defer if (similar.len > 0) allocator.free(similar);
         if (similar.len > 0) {
@@ -251,6 +279,49 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
     const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is installed", .{ name, version });
     defer allocator.free(done_title);
     out.section(done_title);
+}
+
+/// Install a cask by token: fetch metadata, download, extract, stage binaries, link.
+fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: Output, err_out: Output) anyerror!void {
+    // Quick existence check using the cask index.
+    var cask_idx = try CaskIndex.loadOrBuild(allocator, config.cache);
+    const cask_entry = cask_idx.lookup(name) orelse {
+        err_out.err("No available cask with the name \"{s}\".", .{name});
+        std.process.exit(1);
+    };
+
+    // Check deprecated/disabled status.
+    const cask_disabled = (cask_entry.flags & 2) != 0;
+    const cask_deprecated = (cask_entry.flags & 1) != 0;
+    if (cask_disabled) {
+        err_out.err("Cask \"{s}\" is disabled.", .{name});
+        std.process.exit(1);
+    }
+    if (cask_deprecated) {
+        out.warn("Cask \"{s}\" is deprecated.", .{name});
+    }
+
+    // Fetch full per-cask metadata from API.
+    var http_client = HttpClient.init(allocator);
+    defer http_client.deinit();
+
+    out.print("Fetching cask metadata for {s}...\n", .{name});
+    const resolved = cask_mod.fetchAndResolveCask(allocator, &http_client, name) catch |fetch_err| {
+        err_out.err("Failed to fetch cask metadata for \"{s}\": {s}", .{ name, @errorName(fetch_err) });
+        return fetch_err;
+    };
+    defer cask_mod.freeResolvedCask(allocator, resolved);
+
+    // Check if this cask has any binary artifacts.
+    if (resolved.binaries.len == 0) {
+        err_out.warn("No CLI binaries for cask \"{s}\".", .{name});
+        err_out.print("This cask provides only a GUI application.\n", .{});
+        err_out.print("Use: brew install --cask {s}\n", .{name});
+        return;
+    }
+
+    // Run the cask install pipeline.
+    try cask_install.installCask(allocator, config, &http_client, resolved);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/download.zig
+++ b/src/download.zig
@@ -29,6 +29,83 @@ pub const Download = struct {
         return std.fmt.allocPrint(self.allocator, "{s}/blobs/{s}.tar.gz", .{ self.cache_dir, sha256 });
     }
 
+    /// Infer a file extension from a URL (e.g., ".dmg", ".zip", ".tar.gz").
+    pub fn urlExtension(url: []const u8) []const u8 {
+        // Strip query string and fragment.
+        const path = if (std.mem.indexOfScalar(u8, url, '?')) |q| url[0..q] else url;
+        const clean = if (std.mem.indexOfScalar(u8, path, '#')) |h| path[0..h] else path;
+
+        if (std.mem.endsWith(u8, clean, ".tar.gz")) return ".tar.gz";
+        if (std.mem.endsWith(u8, clean, ".tar.bz2")) return ".tar.bz2";
+        if (std.mem.endsWith(u8, clean, ".tar.xz")) return ".tar.xz";
+
+        const basename = std.fs.path.basename(clean);
+        if (std.mem.lastIndexOfScalar(u8, basename, '.')) |dot| {
+            return basename[dot..];
+        }
+        return "";
+    }
+
+    /// Return the blob store path for a content-addressed cask archive.
+    /// Unlike bottles (always .tar.gz), cask archives preserve the original extension.
+    /// Format: {cache_dir}/blobs/{sha256}{ext}
+    pub fn caskBlobPath(self: Download, sha256: []const u8, url: []const u8) ![]const u8 {
+        const ext = urlExtension(url);
+        return std.fmt.allocPrint(self.allocator, "{s}/blobs/{s}{s}", .{ self.cache_dir, sha256, ext });
+    }
+
+    /// Download a cask archive, using cache if available and checksum matches.
+    /// Uses plain HTTP (not GHCR auth). Returns the blob path (caller owns the string).
+    /// If sha256 is "no_check", skips checksum verification.
+    pub fn fetchCask(self: Download, url: []const u8, expected_sha256: []const u8) ![]const u8 {
+        const no_check = std.mem.eql(u8, expected_sha256, "no_check");
+
+        // For no_check casks, use a hash of the URL as the blob name.
+        const blob = if (no_check) blk: {
+            var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+            hasher.update(url);
+            const digest = hasher.finalResult();
+            const hex = std.fmt.bytesToHex(digest, .lower);
+            const ext = urlExtension(url);
+            break :blk try std.fmt.allocPrint(self.allocator, "{s}/blobs/{s}{s}", .{ self.cache_dir, hex, ext });
+        } else try self.caskBlobPath(expected_sha256, url);
+        errdefer self.allocator.free(blob);
+
+        // Check blob store first.
+        if (!no_check) {
+            if (verifySha256(blob, expected_sha256) catch false) {
+                return blob;
+            }
+        } else {
+            // For no_check, just see if the file exists.
+            if (std.fs.cwd().access(blob, .{})) |_| {
+                return blob;
+            } else |_| {}
+        }
+
+        // Ensure the blobs directory exists.
+        const blobs_dir = try std.fmt.allocPrint(self.allocator, "{s}/blobs", .{self.cache_dir});
+        defer self.allocator.free(blobs_dir);
+        std.fs.cwd().makePath(blobs_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+
+        // Download via plain HTTP (no GHCR auth needed for casks).
+        try self.http_client.fetch(url, blob);
+
+        // Verify checksum after download.
+        if (!no_check) {
+            const valid = try verifySha256(blob, expected_sha256);
+            if (!valid) {
+                std.fs.cwd().deleteFile(blob) catch {};
+                return error.ChecksumMismatch;
+            }
+        }
+
+        return blob;
+    }
+
     /// Download a bottle, using cache if available and checksum matches.
     /// Returns the blob path (caller owns the string).
     pub fn fetchBottle(self: Download, url: []const u8, name: []const u8, expected_sha256: []const u8) ![]const u8 {
@@ -243,4 +320,33 @@ test "ghcrImageName replaces both @ and +" {
     const result = try ghcrImageName(allocator, "lib+tool@2");
     defer allocator.free(result);
     try std.testing.expectEqualStrings("libxtool/2", result);
+}
+
+test "urlExtension detects common extensions" {
+    try std.testing.expectEqualStrings(".dmg", Download.urlExtension("https://example.com/app.dmg"));
+    try std.testing.expectEqualStrings(".zip", Download.urlExtension("https://example.com/app.zip"));
+    try std.testing.expectEqualStrings(".pkg", Download.urlExtension("https://example.com/app.pkg"));
+    try std.testing.expectEqualStrings(".tar.gz", Download.urlExtension("https://example.com/app.tar.gz"));
+    try std.testing.expectEqualStrings(".tar.bz2", Download.urlExtension("https://example.com/app.tar.bz2"));
+}
+
+test "urlExtension strips query string" {
+    try std.testing.expectEqualStrings(".dmg", Download.urlExtension("https://example.com/app.dmg?key=val"));
+}
+
+test "urlExtension returns empty for no extension" {
+    try std.testing.expectEqualStrings("", Download.urlExtension("https://example.com/download"));
+}
+
+test "caskBlobPath preserves extension" {
+    const allocator = std.testing.allocator;
+    var client = HttpClient.init(allocator);
+    defer client.deinit();
+    const dl = Download.init(allocator, "/tmp/bru-test-cache", &client);
+
+    const sha = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
+    const path = try dl.caskBlobPath(sha, "https://example.com/app.dmg");
+    defer allocator.free(path);
+
+    try std.testing.expectEqualStrings("/tmp/bru-test-cache/blobs/abc123def456abc123def456abc123def456abc123def456abc123def456abcd.dmg", path);
 }

--- a/src/help.zig
+++ b/src/help.zig
@@ -8,7 +8,7 @@ pub fn printGeneralHelp(stdout: anytype) !void {
         \\Usage: bru <command> [options] [arguments]
         \\
         \\Core commands:
-        \\  install    Install a formula
+        \\  install    Install a formula or cask
         \\  uninstall  Uninstall a formula
         \\  upgrade    Upgrade outdated formulae
         \\  update     Fetch latest formulae data
@@ -56,10 +56,13 @@ pub fn printCommandHelp(stdout: anytype, command: []const u8) !bool {
 fn getCommandHelp(command: []const u8) ?[]const u8 {
     const entries = .{
         .{ "install",
-            \\Usage: bru install <formula>
+            \\Usage: bru install [--cask] <formula|cask>
             \\
-            \\Install a formula from a pre-built bottle.
-            \\Automatically installs missing dependencies.
+            \\Install a formula or cask.
+            \\Automatically installs missing dependencies for formulae.
+            \\
+            \\Options:
+            \\  --cask  Install a cask (binary-only, CLI tools extracted)
             \\
         },
         .{ "uninstall",

--- a/src/http.zig
+++ b/src/http.zig
@@ -17,6 +17,38 @@ pub const HttpClient = struct {
         try self.fetchInner(url, dest_path, .{}, &.{});
     }
 
+    /// Fetch a URL and return the response body as an owned slice.
+    /// Downloads to a temporary file and reads it back into memory.
+    /// Caller owns the returned memory and must free it with the provided allocator.
+    pub fn fetchToMemory(self: *HttpClient, allocator: std.mem.Allocator, url: []const u8) ![]u8 {
+        // Create a unique temp path using a hash of the URL.
+        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+        hasher.update(url);
+        const digest = hasher.finalResult();
+        const hex = std.fmt.bytesToHex(digest, .lower);
+
+        const nonce = std.time.nanoTimestamp();
+        var tmp_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const tmp_path = try std.fmt.bufPrint(&tmp_path_buf, "/tmp/bru-fetch-{d}-{s}", .{ nonce, hex });
+
+        // Download to temp file.
+        try self.fetch(url, tmp_path);
+        defer std.fs.cwd().deleteFile(tmp_path) catch {};
+
+        // Read into memory.
+        const file = try std.fs.cwd().openFile(tmp_path, .{});
+        defer file.close();
+
+        const stat = try file.stat();
+        const body = try allocator.alloc(u8, stat.size);
+        errdefer allocator.free(body);
+
+        const bytes_read = try file.readAll(body);
+        if (bytes_read != stat.size) return error.UnexpectedEof;
+
+        return body;
+    }
+
     /// Download from GHCR with anonymous auth header (Authorization: Bearer QQ==).
     pub fn fetchGhcr(self: *HttpClient, url: []const u8, dest_path: []const u8) !void {
         try self.fetchInner(url, dest_path, .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,7 @@ test {
     _ = @import("index.zig");
     _ = @import("cask.zig");
     _ = @import("cask_index.zig");
+    _ = @import("cask_install.zig");
     _ = @import("version.zig");
     _ = @import("http.zig");
     _ = @import("batch_download.zig");


### PR DESCRIPTION
## Summary
- Add `bru install --cask <name>` to natively install casks by downloading archives (DMG/ZIP/tar), extracting CLI binary artifacts, and linking them into the prefix
- Suggest `--cask` flag when formula lookup fails but a matching cask exists
- Warn when a cask has no CLI binaries and recommend `brew install --cask` instead

## Test plan
- [x] `zig build test` — all existing and new tests pass
- [x] `zig build -Doptimize=ReleaseFast` — release build compiles
- [ ] `bru install --cask firefox` — downloads DMG, extracts binary, links `firefox` to prefix/bin
- [ ] `bru install android-studio` (without --cask) — suggests `bru install --cask android-studio`
- [ ] `bru install --cask nonexistent` — "No available cask with the name..."
- [ ] `bru install --cask google-chrome` — warns no CLI binaries, suggests brew