### PR TITLE
feat: show searched file path when formula or cask is not found

### DIFF
--- a/src/cmd/deps.zig
+++ b/src/cmd/deps.zig
@@ -66,6 +66,7 @@ pub fn depsCmd(allocator: Allocator, args: []const []const u8, config: Config) a
     const entry = idx.lookup(formula_name.?) orelse {
         const err_out = Output.initErr(config.no_color);
         err_out.err("No available formula with the name \"{s}\".", .{formula_name.?});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
         const similar = fuzzy.findSimilar(&idx, allocator, formula_name.?, 3, 3) catch &.{};
         defer if (similar.len > 0) allocator.free(similar);
         if (similar.len > 0) {

--- a/src/cmd/fetch_cmd.zig
+++ b/src/cmd/fetch_cmd.zig
@@ -33,6 +33,7 @@ pub fn fetchCmd(allocator: Allocator, args: []const []const u8, config: Config) 
     const entry = idx.lookup(formula_name) orelse {
         const err_out = Output.initErr(config.no_color);
         err_out.err("No available formula with the name \"{s}\".", .{formula_name});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
         std.process.exit(1);
     };
 

--- a/src/cmd/info.zig
+++ b/src/cmd/info.zig
@@ -59,6 +59,7 @@ pub fn infoCmd(allocator: Allocator, args: []const []const u8, config: Config) a
 
         const err_out = Output.initErr(config.no_color);
         err_out.err("No available formula or cask with the name \"{s}\".", .{the_name});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
         const similar = fuzzy.findSimilar(&idx, allocator, the_name, 3, 3) catch &.{};
         defer if (similar.len > 0) allocator.free(similar);
         if (similar.len > 0) {

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -84,6 +84,7 @@ pub fn installCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     const entry = idx.lookup(name) orelse {
         err_out.err("No available formula with the name \"{s}\".", .{name});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
 
         // Check if this is a cask and suggest --cask flag.
         const cask_idx = CaskIndex.loadOrBuild(allocator, config.cache) catch null;
@@ -287,6 +288,7 @@ fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: O
     var cask_idx = try CaskIndex.loadOrBuild(allocator, config.cache);
     const cask_entry = cask_idx.lookup(name) orelse {
         err_out.err("No available cask with the name \"{s}\".", .{name});
+        err_out.print("Searched: {s}/api/cask.jws.json\n", .{config.cache});
         std.process.exit(1);
     };
 

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -71,6 +71,7 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
         const entry = index.lookup(name) orelse {
             err_out.err("No available formula with the name \"{s}\".", .{name});
+            err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
             std.process.exit(1);
         };
 

--- a/src/cmd/uses.zig
+++ b/src/cmd/uses.zig
@@ -82,6 +82,7 @@ pub fn usesCmd(allocator: Allocator, args: []const []const u8, config: Config) a
     _ = idx.lookup(formula_name.?) orelse {
         const err_out = Output.initErr(config.no_color);
         err_out.err("No available formula with the name \"{s}\".", .{formula_name.?});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
         const similar = fuzzy.findSimilar(&idx, allocator, formula_name.?, 3, 3) catch &.{};
         defer if (similar.len > 0) allocator.free(similar);
         if (similar.len > 0) {


### PR DESCRIPTION
## Summary
- Displays the data source file path (e.g. `formula.jws.json` or `cask.jws.json`) in "not found" errors so users can see where bru searched

## Test plan
- [x] `zig build` compiles cleanly
- [x] `zig build test` passes
- [x] Verified output: `bru install mod` now shows `Searched: .../api/formula.jws.json`