### PR TITLE
fix: exclude cask entries from list --versions output

### DIFF
--- a/src/cellar.zig
+++ b/src/cellar.zig
@@ -84,6 +84,12 @@ pub const Cellar = struct {
             if (entry.kind != .directory and entry.kind != .unknown) continue;
             if (entry.name.len > 0 and entry.name[0] == '.') continue;
 
+            // On macOS/APFS, symlinks to directories may be reported as .directory
+            // rather than .sym_link. Attempt readLink to detect and skip symlinks
+            // (e.g. cask aliases like gcloud-cli -> google-cloud-sdk).
+            var link_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (dir.readLink(entry.name, &link_buf)) |_| continue else |_| {}
+
             const name = allocator.dupe(u8, entry.name) catch continue;
             const versions = self.installedVersions(allocator, name) orelse {
                 allocator.free(name);

--- a/src/cmd/list.zig
+++ b/src/cmd/list.zig
@@ -85,7 +85,7 @@ pub fn listCmd(allocator: Allocator, args: []const []const u8, config: Config) a
         }
         allocator.free(casks);
     }
-    if (!only_formulae) {
+    if (!only_formulae and !(show_versions and !only_casks)) {
         const cr = Cellar.init(config.caskroom);
         casks = cr.installedFormulae(allocator);
     }


### PR DESCRIPTION
## Summary
- Skip Caskroom scan in `list --versions` unless `--cask` is explicitly passed, matching `brew list --versions` which only shows formulae
- Filter symlink aliases in `installedFormulae()` via `readLink` since macOS/APFS can report symlinks-to-directories as `.directory` entries

Closes #37