### PR TITLE
fix: dangling stack pointer segfault in upgrade for revisioned packages

### DIFF
--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -68,9 +68,8 @@ fn prepareOne(arena: Allocator, ctx: PrepareContext, item: OutdatedFormula) Prep
     }
 
     const version_base = ctx.index.getString(entry.version_offset);
-    var pkg_ver_buf_main: [256]u8 = undefined;
     const version = if (entry.revision > 0)
-        std.fmt.bufPrint(&pkg_ver_buf_main, "{s}_{d}", .{ version_base, entry.revision }) catch version_base
+        std.fmt.allocPrint(arena, "{s}_{d}", .{ version_base, entry.revision }) catch version_base
     else
         version_base;
 


### PR DESCRIPTION
## Summary

- Fixes segfault in `bru upgrade` when upgrading packages with `revision > 0` (e.g. `jupyterlab 4.5.6_1`)
- `prepareOne()` formatted the version string into a stack-local buffer, returned the pointer in `PrepareResult.success.version`, then the stack frame was destroyed — leaving the swap phase reading dead memory
- Replaced `bufPrint` (stack buffer) with `allocPrint` (arena allocation) so the version string lives as long as the result

## Reproduction

Crash occurs when upgrading any formula with a non-zero revision suffix (the `_1` in `4.5.6_1`). In the reported case, packages 1-9 (awscli → jpeg-turbo) had `revision == 0` and succeeded; the 10th (jupyterlab `4.5.6_1`, `revision == 1`) triggered the dangling pointer.

## Test plan

- [ ] CI passes (`zig build test`)
- [ ] `bru upgrade` with a mix of revisioned and non-revisioned packages completes without segfault