### PR TITLE
Harden Mach-O relocation and add LC_RPATH parity

### DIFF
--- a/src/bottle.zig
+++ b/src/bottle.zig
@@ -614,6 +614,43 @@ pub const Bottle = struct {
             }
         }
 
+        // Parse otool -l output for LC_RPATH entries with placeholders.
+        // Homebrew bottles can embed @rpath search entries that must also be
+        // rewritten; otherwise dependent dylibs fail to resolve at runtime.
+        const otool_all = std.process.Child.run(.{
+            .allocator = self.allocator,
+            .argv = &.{ "otool", "-l", full_path },
+        }) catch null;
+        if (otool_all) |cmd_out| {
+            defer self.allocator.free(cmd_out.stdout);
+            defer self.allocator.free(cmd_out.stderr);
+
+            var lines = mem.splitScalar(u8, cmd_out.stdout, '\n');
+            var in_rpath = false;
+            while (lines.next()) |line| {
+                const trimmed = mem.trim(u8, line, " \t");
+                if (mem.eql(u8, trimmed, "cmd LC_RPATH")) {
+                    in_rpath = true;
+                    continue;
+                }
+                if (!in_rpath) continue;
+                if (!mem.startsWith(u8, trimmed, "path ")) continue;
+
+                in_rpath = false;
+                const after = trimmed[5..];
+                const end = mem.indexOf(u8, after, " (") orelse after.len;
+                const old_rpath = mem.trim(u8, after[0..end], " \t");
+                if (!hasPlaceholder(old_rpath)) continue;
+
+                const new_rpath = try self.replacePlaceholderPath(old_rpath);
+
+                try args.append(self.allocator, "-rpath");
+                try args.append(self.allocator, try self.allocator.dupe(u8, old_rpath));
+                try args.append(self.allocator, new_rpath);
+                has_changes = true;
+            }
+        }
+
         if (!has_changes) return;
 
         try args.append(self.allocator, try self.allocator.dupe(u8, full_path));
@@ -641,12 +678,13 @@ pub const Bottle = struct {
     }
 
     /// Check if a string was heap-allocated (not a string literal from argv).
-    /// We know literals are "install_name_tool", "-id", "-change"; everything
-    /// else was allocated.
+    /// We know literals are "install_name_tool", "-id", "-change", "-rpath";
+    /// everything else was allocated.
     fn isPlaceholderAllocated(s: []const u8) bool {
         return !mem.eql(u8, s, "install_name_tool") and
             !mem.eql(u8, s, "-id") and
-            !mem.eql(u8, s, "-change");
+            !mem.eql(u8, s, "-change") and
+            !mem.eql(u8, s, "-rpath");
     }
 
     /// Replace @@HOMEBREW_CELLAR@@ and @@HOMEBREW_PREFIX@@ in a path string.
@@ -1237,6 +1275,90 @@ test "relocateMachO rewrites placeholder install name in Mach-O dylib" {
     try std.testing.expect(mem.indexOf(u8, after.stdout, "@@HOMEBREW_PREFIX@@") == null);
     try std.testing.expect(
         mem.indexOf(u8, after.stdout, "/opt/homebrew/opt/brutest/lib/libbrutest.dylib") != null,
+    );
+}
+
+test "relocateMachO rewrites placeholder LC_RPATH entries" {
+    const builtin = @import("builtin");
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Build a dylib with headerpad so we can inject an rpath without
+    // overflowing load command capacity (mirrors how Homebrew builds bottles).
+    try tmp.dir.makePath("lib");
+    try tmp.dir.writeFile(.{ .sub_path = "lib/libpad.c", .data = "int f(void){return 1;}\n" });
+
+    var tmp_buf: [fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp.dir.realpath(".", &tmp_buf);
+
+    const c_path = try std.fmt.allocPrint(allocator, "{s}/lib/libpad.c", .{tmp_path});
+    defer allocator.free(c_path);
+    const dylib_path = try std.fmt.allocPrint(allocator, "{s}/lib/libpad.dylib", .{tmp_path});
+    defer allocator.free(dylib_path);
+
+    const cc = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "cc", "-dynamiclib", "-Wl,-headerpad_max_install_names", "-o", dylib_path, c_path },
+    });
+    allocator.free(cc.stdout);
+    allocator.free(cc.stderr);
+    try std.testing.expect(cc.term == .Exited and cc.term.Exited == 0);
+
+    // Inject a placeholder rpath.
+    const add_rpath = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{
+            "install_name_tool",
+            "-add_rpath",
+            "@@HOMEBREW_PREFIX@@/opt/provider/lib",
+            dylib_path,
+        },
+    });
+    allocator.free(add_rpath.stdout);
+    allocator.free(add_rpath.stderr);
+    try std.testing.expect(add_rpath.term == .Exited and add_rpath.term.Exited == 0);
+
+    const cs = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "codesign", "--force", "--sign", "-", dylib_path },
+    });
+    allocator.free(cs.stdout);
+    allocator.free(cs.stderr);
+
+    // Sanity: otool -l shows the placeholder rpath.
+    {
+        const before = try std.process.Child.run(.{
+            .allocator = allocator,
+            .argv = &.{ "otool", "-l", dylib_path },
+        });
+        defer allocator.free(before.stdout);
+        defer allocator.free(before.stderr);
+        try std.testing.expect(
+            mem.indexOf(u8, before.stdout, "@@HOMEBREW_PREFIX@@/opt/provider/lib") != null,
+        );
+    }
+
+    const bottle = Bottle{
+        .allocator = allocator,
+        .cellar = "/opt/homebrew/Cellar",
+        .prefix = "/opt/homebrew",
+    };
+    try bottle.relocateMachO(tmp_path);
+
+    // The placeholder rpath is gone and rewritten to the real prefix.
+    const after_rpath = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "otool", "-l", dylib_path },
+    });
+    defer allocator.free(after_rpath.stdout);
+    defer allocator.free(after_rpath.stderr);
+    try std.testing.expect(mem.indexOf(u8, after_rpath.stdout, "@@HOMEBREW_PREFIX@@") == null);
+    try std.testing.expect(
+        mem.indexOf(u8, after_rpath.stdout, "/opt/homebrew/opt/provider/lib") != null,
     );
 }
 

--- a/src/bottle.zig
+++ b/src/bottle.zig
@@ -1135,3 +1135,108 @@ test "pourWithCache returns cached keg on second call" {
     try std.testing.expectEqualStrings("#!/bin/sh\necho cachepkg\n", extracted2);
 }
 
+// Compile a trivial C file to a Mach-O dylib and stamp placeholder paths into
+// its load commands. Returns the absolute dylib path; caller owns it.
+fn buildDylibWithPlaceholders(
+    allocator: Allocator,
+    tmp_dir: fs.Dir,
+    subpath: []const u8,
+    placeholder_id: []const u8,
+) ![]const u8 {
+    const dir = std.fs.path.dirname(subpath) orelse ".";
+    try tmp_dir.makePath(dir);
+
+    const c_subpath = try std.fmt.allocPrint(allocator, "{s}.c", .{subpath});
+    defer allocator.free(c_subpath);
+
+    try tmp_dir.writeFile(.{
+        .sub_path = c_subpath,
+        .data = "int bru_test_fn(void) { return 42; }\n",
+    });
+
+    var tmp_buf: [fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp_dir.realpath(".", &tmp_buf);
+
+    const c_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmp_path, c_subpath });
+    defer allocator.free(c_path);
+
+    const dylib_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmp_path, subpath });
+    errdefer allocator.free(dylib_path);
+
+    const cc = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "cc", "-dynamiclib", "-o", dylib_path, c_path },
+    });
+    allocator.free(cc.stdout);
+    allocator.free(cc.stderr);
+    if (cc.term != .Exited or cc.term.Exited != 0) return error.TestCompileFailed;
+
+    const int = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "install_name_tool", "-id", placeholder_id, dylib_path },
+    });
+    allocator.free(int.stdout);
+    allocator.free(int.stderr);
+    if (int.term != .Exited or int.term.Exited != 0) return error.TestInstallNameToolFailed;
+
+    const cs = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "codesign", "--force", "--sign", "-", dylib_path },
+    });
+    allocator.free(cs.stdout);
+    allocator.free(cs.stderr);
+
+    return dylib_path;
+}
+
+test "relocateMachO rewrites placeholder install name in Mach-O dylib" {
+    const builtin = @import("builtin");
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dylib_path = try buildDylibWithPlaceholders(
+        allocator,
+        tmp.dir,
+        "lib/libbrutest.dylib",
+        "@@HOMEBREW_PREFIX@@/opt/brutest/lib/libbrutest.dylib",
+    );
+    defer allocator.free(dylib_path);
+
+    var keg_buf: [fs.max_path_bytes]u8 = undefined;
+    const keg_path = try tmp.dir.realpath(".", &keg_buf);
+
+    // Sanity: placeholder is present before relocation.
+    {
+        const before = try std.process.Child.run(.{
+            .allocator = allocator,
+            .argv = &.{ "otool", "-D", dylib_path },
+        });
+        defer allocator.free(before.stdout);
+        defer allocator.free(before.stderr);
+        try std.testing.expect(mem.indexOf(u8, before.stdout, "@@HOMEBREW_PREFIX@@") != null);
+    }
+
+    const bottle = Bottle{
+        .allocator = allocator,
+        .cellar = "/opt/homebrew/Cellar",
+        .prefix = "/opt/homebrew",
+    };
+    try bottle.relocateMachO(keg_path);
+
+    // Placeholder is gone and rewritten to the real prefix.
+    const after = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "otool", "-D", dylib_path },
+    });
+    defer allocator.free(after.stdout);
+    defer allocator.free(after.stderr);
+    try std.testing.expect(mem.indexOf(u8, after.stdout, "@@HOMEBREW_PREFIX@@") == null);
+    try std.testing.expect(
+        mem.indexOf(u8, after.stdout, "/opt/homebrew/opt/brutest/lib/libbrutest.dylib") != null,
+    );
+}
+

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -102,8 +102,11 @@ fn prepareOne(arena: Allocator, ctx: PrepareContext, item: OutdatedFormula) Prep
         return .{ .failure = .{ .err_name = @errorName(err) } };
     };
 
-    // Replace placeholders.
+    // Replace placeholders in text files and Mach-O binaries. Without the
+    // relocateMachO step, dylibs retain literal @@HOMEBREW_PREFIX@@ paths in
+    // their load commands and fail to resolve dependencies at runtime.
     bottle_inst.replacePlaceholders(keg_path) catch {};
+    bottle_inst.relocateMachO(keg_path) catch {};
 
     // Build runtime_dependencies and write install receipt.
     {


### PR DESCRIPTION
## Summary
- Cherry-picks the unpushed local-main fix that adds `relocateMachO` to the upgrade path, which was the root cause of the openssl@3/mpv breakage (`dyld Symbol not found _ASN1_INTEGER_cmp` from unresolved `@@HOMEBREW_PREFIX@@` load commands).
- Adds the first unit tests for `relocateMachO`. The function previously had zero direct coverage — that is why the upgrade-path regression slipped in. Each new test was verified as real coverage by disabling the code under test and watching it fail.
- Closes a parity gap with Homebrew: bru was rewriting `LC_ID_DYLIB` and `LC_LOAD_DYLIB` but ignoring `LC_RPATH`. Upstream handles this via `change_rpath` in `extend/os/mac/keg_relocate.rb`. Now `install_name_tool -rpath OLD NEW` is emitted for any LC_RPATH entry containing a placeholder.

## Test plan
- [x] `zig build test` — 271/271 pass (was 269; +2 new)
- [x] Disable `relocateMachO` body → both new tests fail (regression coverage confirmed)
- [x] Disable just the LC_RPATH parsing block → rpath test fails, install-name test still passes (orthogonal coverage)
