### PR TITLE
ci: detect conventional commits in squash-merge body bullets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,16 @@ jobs:
           echo "Commits since ${LATEST_TAG}:"
           echo "$SUBJECTS" | sed 's/^/  /'
 
+          # Collect candidate conventional-commit lines from both subjects
+          # and body bullets. GitHub squash-merges put the PR title in the
+          # subject and nest each original commit as "* type: ..." in the
+          # body, so scanning subjects alone misses squash-merged PRs whose
+          # title is not itself a conventional commit.
+          CANDIDATES=$(
+            printf '%s\n' "$SUBJECTS"
+            printf '%s\n' "$BODIES" | sed -nE 's/^[[:space:]]*\*[[:space:]]+//p'
+          )
+
           # Determine bump type from conventional commits
           # Priority: major > minor > patch > none
           BUMP="none"
@@ -84,7 +94,7 @@ jobs:
             if echo "$msg" | grep -qE '^(fix|perf|refactor)(\(.+\))?:'; then
               [[ "$BUMP" == "none" ]] && BUMP="patch"
             fi
-          done <<< "$SUBJECTS"
+          done <<< "$CANDIDATES"
 
           if [[ "$BUMP" == "none" ]]; then
             echo "No releasable commits (only docs/ci/chore/etc.) — skipping release"


### PR DESCRIPTION
## Summary
- PR #106 was correctly squash-merged but did not trigger a release because the version job only scans commit **subjects** for conventional-commit types, and GitHub's default squash-merge used the PR title (`Harden Mach-O relocation and add LC_RPATH parity (#106)`) as the subject — not a conventional commit.
- GitHub nests each original commit as `* type: ...` in the merge body. Scan those too.

## Test plan
- [x] Dry-run against the offending squash commit (`03b642f`): correctly detects `BUMP=minor` (was `none`)
- [ ] After merge, dispatch the release manually for `v0.4.0` to publish the openssl@3 fix + LC_RPATH feature from #106

## Notes
- The PR title here starts with `ci:`, which is intentionally not a releasable type — this fix shouldn't ship its own release.