### PR TITLE
feat: add bru relocate to repair pre-fix broken kegs

### DIFF
--- a/src/cmd/relocate.zig
+++ b/src/cmd/relocate.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const fs = std.fs;
+const Allocator = std.mem.Allocator;
+const Config = @import("../config.zig").Config;
+const Cellar = @import("../cellar.zig").Cellar;
+const Bottle = @import("../bottle.zig").Bottle;
+const Output = @import("../output.zig").Output;
+
+/// `bru relocate [name...]`: re-run placeholder replacement and Mach-O load
+/// command relocation on installed kegs. Repairs kegs whose dylibs still
+/// contain literal @@HOMEBREW_PREFIX@@ paths (for example, after a pre-fix
+/// `bru upgrade` that skipped the relocation step).
+///
+/// With no arguments, sweeps every installed formula in the cellar. With one
+/// or more formula names, processes only those.
+pub fn relocateCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
+    const out = Output.init(config.no_color);
+    const err_out = Output.initErr(config.no_color);
+
+    const bottle = Bottle.init(allocator, config);
+
+    var ok: usize = 0;
+    var fail: usize = 0;
+
+    if (args.len == 0) {
+        const cellar = Cellar.init(config.cellar);
+        const formulae = cellar.installedFormulae(allocator);
+        defer {
+            for (formulae) |f| {
+                for (f.versions) |v| allocator.free(v);
+                allocator.free(f.versions);
+                allocator.free(f.name);
+            }
+            allocator.free(formulae);
+        }
+
+        if (formulae.len == 0) {
+            out.print("No installed formulae found in {s}.\n", .{config.cellar});
+            return;
+        }
+
+        out.section("Relocating all installed formulae");
+        for (formulae) |f| {
+            if (relocateOne(allocator, bottle, config, f.name, out, err_out)) ok += 1 else fail += 1;
+        }
+    } else {
+        for (args) |name| {
+            if (relocateOne(allocator, bottle, config, name, out, err_out)) ok += 1 else fail += 1;
+        }
+    }
+
+    out.print("Relocated {d} keg(s)", .{ok});
+    if (fail > 0) out.print(", {d} failed", .{fail});
+    out.print(".\n", .{});
+}
+
+/// Relocate every installed version of `name`. Returns true if at least one
+/// keg was processed successfully, false if the formula is not installed or
+/// every version failed.
+fn relocateOne(
+    allocator: Allocator,
+    bottle: Bottle,
+    config: Config,
+    name: []const u8,
+    out: Output,
+    err_out: Output,
+) bool {
+    const cellar = Cellar.init(config.cellar);
+    const versions = cellar.installedVersions(allocator, name) orelse {
+        err_out.warn("{s} is not installed.", .{name});
+        return false;
+    };
+    defer {
+        for (versions) |v| allocator.free(v);
+        allocator.free(versions);
+    }
+
+    var any_ok = false;
+    for (versions) |version| {
+        const keg_path = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{
+            config.cellar,
+            name,
+            version,
+        }) catch {
+            err_out.warn("{s} {s}: out of memory building keg path", .{ name, version });
+            continue;
+        };
+        defer allocator.free(keg_path);
+
+        out.print("==> {s} {s}\n", .{ name, version });
+
+        bottle.replacePlaceholders(keg_path) catch |err| {
+            err_out.warn("{s} {s}: replacePlaceholders failed: {s}", .{ name, version, @errorName(err) });
+            continue;
+        };
+        bottle.relocateMachO(keg_path) catch |err| {
+            err_out.warn("{s} {s}: relocateMachO failed: {s}", .{ name, version, @errorName(err) });
+            continue;
+        };
+        any_ok = true;
+    }
+
+    return any_ok;
+}

--- a/src/dispatch.zig
+++ b/src/dispatch.zig
@@ -35,6 +35,7 @@ const completions = @import("cmd/completions.zig");
 const env_cmd = @import("cmd/env.zig");
 const migrate = @import("cmd/migrate.zig");
 const rollback = @import("cmd/rollback.zig");
+const relocate = @import("cmd/relocate.zig");
 const bundle = @import("cmd/bundle.zig");
 const services = @import("cmd/services.zig");
 const self_update = @import("cmd/self_update.zig");
@@ -104,6 +105,7 @@ pub const native_commands = [_]CommandEntry{
     .{ .name = "env", .handler = env_cmd.envCmd },
     .{ .name = "migrate", .handler = migrate.migrateCmd },
     .{ .name = "rollback", .handler = rollback.rollbackCmd },
+    .{ .name = "relocate", .handler = relocate.relocateCmd },
     .{ .name = "bundle", .handler = bundle.bundleCmd },
     .{ .name = "services", .handler = services.servicesCmd },
     .{ .name = "self-update", .handler = self_update.selfUpdateCmd },

--- a/src/output.zig
+++ b/src/output.zig
@@ -31,7 +31,7 @@ pub const Output = struct {
     /// Write formatted text to the output.
     pub fn print(self: Output, comptime fmt: []const u8, args: anytype) void {
         var buf: [4096]u8 = undefined;
-        var w = self.file.writer(&buf);
+        var w = self.file.writerStreaming(&buf);
         const writer = &w.interface;
         writer.print(fmt, args) catch {};
         writer.flush() catch {};
@@ -42,7 +42,7 @@ pub const Output = struct {
     /// Without color: plain "==> Title\n".
     pub fn section(self: Output, title: []const u8) void {
         var buf: [4096]u8 = undefined;
-        var w = self.file.writer(&buf);
+        var w = self.file.writerStreaming(&buf);
         const writer = &w.interface;
 
         if (self.use_color) {
@@ -57,7 +57,7 @@ pub const Output = struct {
     /// With color: yellow "Warning:" prefix.
     pub fn warn(self: Output, comptime fmt: []const u8, args: anytype) void {
         var buf: [4096]u8 = undefined;
-        var w = self.file.writer(&buf);
+        var w = self.file.writerStreaming(&buf);
         const writer = &w.interface;
 
         if (self.use_color) {
@@ -76,7 +76,7 @@ pub const Output = struct {
     /// Use Output.initErr() to target stderr.
     pub fn err(self: Output, comptime fmt: []const u8, args: anytype) void {
         var buf: [4096]u8 = undefined;
-        var w = self.file.writer(&buf);
+        var w = self.file.writerStreaming(&buf);
         const writer = &w.interface;
 
         if (self.use_color) {


### PR DESCRIPTION
## Summary
Adds \`bru relocate [name...]\` which re-runs placeholder replacement and Mach-O load-command relocation on already-installed kegs — a pure repair pass, no download. With no args it sweeps the entire cellar.

Needed because any keg that bru upgraded before d19e4e0 / v0.4.0 still has literal \`@@HOMEBREW_PREFIX@@\` paths in its dylib load commands. Symptoms are cryptic dyld failures like \`Symbol not found: _ASN1_INTEGER_cmp / Expected in: <no uuid> unknown\` — one reporter hit this on openssl@3, and I personally hit the same class of error on libarchive → freetype → harfbuzz while trying to run mpv.

Also fixes a latent **Output.print** bug: each call created a new positional writer at offset 0, causing multi-print output to overwrite itself whenever stdout was redirected to a regular file (e.g. \`bru ... > out.txt\`). Interactive TTY masked the bug. Switched to \`writerStreaming\` so successive prints append.

## Test plan
- [x] \`zig build test\` — 271/271 pass
- [x] Swept a 184-keg real cellar: 0 errors, exit 0
- [x] \`bru relocate libarchive\` — before: 6 \`@@HOMEBREW_PREFIX@@\` entries in \`otool -L\`; after: all rewritten to \`/opt/homebrew/opt/...\`
- [x] \`mpv\` runs clean after sweep (was broken through 3 successive symbol failures before repair)
- [x] \`bru list > /tmp/out.txt\` no longer corrupted by the Output bug

## Follow-ups (not in this PR)
- Parallelize the per-keg relocation (currently sequential, ~minutes on a large cellar)
- Add \`--dry-run\` to preview which kegs would be touched
- Surface the silent \`catch return\` paths inside \`relocateFileIfMachO\` so failures print instead of hiding