### PR TITLE
feat: support cask upgrades

### DIFF
--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -12,22 +12,36 @@ const ResolvedCask = cask.ResolvedCask;
 const BinaryArtifact = cask.BinaryArtifact;
 
 /// Install a cask: download archive, extract, stage binaries, and link.
-pub fn installCask(allocator: Allocator, config: Config, http_client: *HttpClient, resolved: ResolvedCask) !void {
+///
+/// When `upgrade_from` is null this is a fresh install and fails if the cask
+/// is already in the caskroom. When `upgrade_from` is a version string the
+/// "already installed" guard is skipped; after the new version is linked the
+/// old version's symlinks are unlinked and its caskroom directory is removed.
+pub fn installCask(
+    allocator: Allocator,
+    config: Config,
+    http_client: *HttpClient,
+    resolved: ResolvedCask,
+    upgrade_from: ?[]const u8,
+) !void {
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
 
-    // 1. Check if already installed.
-    var caskroom_check_buf: [fs.max_path_bytes]u8 = undefined;
-    const caskroom_check = std.fmt.bufPrint(&caskroom_check_buf, "{s}/{s}", .{ config.caskroom, resolved.token }) catch unreachable;
-    if (fs.openDirAbsolute(caskroom_check, .{})) |dir| {
-        var d = dir;
-        d.close();
-        out.warn("{s} is already installed.", .{resolved.token});
-        return;
-    } else |_| {}
+    // 1. Check if already installed (skip for upgrades).
+    if (upgrade_from == null) {
+        var caskroom_check_buf: [fs.max_path_bytes]u8 = undefined;
+        const caskroom_check = std.fmt.bufPrint(&caskroom_check_buf, "{s}/{s}", .{ config.caskroom, resolved.token }) catch unreachable;
+        if (fs.openDirAbsolute(caskroom_check, .{})) |dir| {
+            var d = dir;
+            d.close();
+            out.warn("{s} is already installed.", .{resolved.token});
+            return;
+        } else |_| {}
+    }
 
     // 2. Print section header.
-    const install_title = try std.fmt.allocPrint(allocator, "Installing {s} {s}", .{ resolved.name, resolved.version });
+    const action = if (upgrade_from != null) "Upgrading" else "Installing";
+    const install_title = try std.fmt.allocPrint(allocator, "{s} {s} {s}", .{ action, resolved.name, resolved.version });
     defer allocator.free(install_title);
     out.section(install_title);
 
@@ -74,12 +88,37 @@ pub fn installCask(allocator: Allocator, config: Config, http_client: *HttpClien
         }
     }
 
-    // 7. Link into prefix.
+    // 7. Link into prefix. For upgrades, first unlink the old version's
+    //    symlinks so the new link can replace them cleanly.
     var linker = Linker.init(allocator, config.prefix);
+
+    if (upgrade_from) |old_version| {
+        if (!mem.eql(u8, old_version, resolved.version)) {
+            const old_version_dir = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ config.caskroom, resolved.token, old_version });
+            defer allocator.free(old_version_dir);
+            linker.unlink(old_version_dir) catch |unlink_err| {
+                err_out.warn("Failed to unlink old {s} {s}: {s}", .{ resolved.token, old_version, @errorName(unlink_err) });
+            };
+        }
+    }
+
     try linker.link(resolved.token, version_dir);
 
-    // 8. Print completion.
-    const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is installed", .{ resolved.name, resolved.version });
+    // 8. For upgrades, remove the old caskroom version dir now that the new
+    //    one is linked.
+    if (upgrade_from) |old_version| {
+        if (!mem.eql(u8, old_version, resolved.version)) {
+            const old_version_dir = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ config.caskroom, resolved.token, old_version });
+            defer allocator.free(old_version_dir);
+            fs.deleteTreeAbsolute(old_version_dir) catch |del_err| {
+                err_out.warn("Failed to remove old {s} {s}: {s}", .{ resolved.token, old_version, @errorName(del_err) });
+            };
+        }
+    }
+
+    // 9. Print completion.
+    const done_verb = if (upgrade_from != null) "upgraded" else "installed";
+    const done_title = try std.fmt.allocPrint(allocator, "{s} {s} is {s}", .{ resolved.name, resolved.version, done_verb });
     defer allocator.free(done_title);
     out.section(done_title);
 }

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -405,7 +405,7 @@ fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: O
     }
 
     // Run the cask install pipeline.
-    try cask_install.installCask(allocator, config, &http_client, resolved);
+    try cask_install.installCask(allocator, config, &http_client, resolved, null);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd/outdated.zig
+++ b/src/cmd/outdated.zig
@@ -4,6 +4,7 @@ const Config = @import("../config.zig").Config;
 const cellar_mod = @import("../cellar.zig");
 const Cellar = cellar_mod.Cellar;
 const Index = @import("../index.zig").Index;
+const CaskIndex = @import("../cask_index.zig").CaskIndex;
 const PkgVersion = @import("../version.zig").PkgVersion;
 const writeJsonStr = @import("../json_helpers.zig").writeJsonStr;
 
@@ -18,30 +19,45 @@ fn isOptLinked(prefix: []const u8, name: []const u8) bool {
     return true;
 }
 
-/// Show installed formulae that have a newer version available in the index.
-///
-/// With --verbose / -v: prints "name (installed_ver) < latest_ver"
-/// Otherwise: just prints "name"
-pub fn outdatedCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
-    var verbose = false;
-    var json_output = false;
+const ParsedOutdatedArgs = struct {
+    verbose: bool = false,
+    json_output: bool = false,
+    only_formulae: bool = false,
+    only_casks: bool = false,
+};
+
+fn parseOutdatedArgs(args: []const []const u8) ParsedOutdatedArgs {
+    var result = ParsedOutdatedArgs{};
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
-            verbose = true;
+            result.verbose = true;
         } else if (std.mem.eql(u8, arg, "--json")) {
-            json_output = true;
+            result.json_output = true;
+        } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
+            result.only_formulae = true;
+        } else if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
+            result.only_casks = true;
         }
     }
+    return result;
+}
 
-    // Load the index from disk or build from the JWS cache.
-    var index = try Index.loadOrBuild(allocator, config.cache);
-    // Note: do not call index.deinit() -- the index may be mmap'd (from disk)
-    // in which case the allocator field is undefined. The process exits after
-    // this command so OS reclamation is sufficient.
-    _ = &index;
+/// A reported outdated entry, used internally for both formulae and casks.
+const OutdatedEntry = struct {
+    name: []const u8,
+    installed_version: []const u8,
+    latest_version: []const u8, // pre-formatted; for formulae includes _revision
+};
 
-    // Get all installed formulae from the cellar.
-    const cellar = Cellar.init(config.cellar);
+/// Collect outdated formulae from the cellar against the formula index.
+fn collectOutdatedFormulae(
+    allocator: Allocator,
+    index: *Index,
+    cellar: Cellar,
+    prefix: []const u8,
+    out: *std.ArrayList(OutdatedEntry),
+    fmt_arena: Allocator,
+) !void {
     const installed = cellar.installedFormulae(allocator);
     defer {
         for (installed) |f| {
@@ -52,76 +68,167 @@ pub fn outdatedCmd(allocator: Allocator, args: []const []const u8, config: Confi
         allocator.free(installed);
     }
 
-    var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
-    const stdout = &w.interface;
-
-    if (json_output) {
-        try stdout.writeAll("[");
-        var first: bool = true;
-        for (installed) |formula| {
-            const entry = index.lookup(formula.name) orelse continue;
-            const index_version_str = index.getString(entry.version_offset);
-            const installed_version_str = formula.latestVersion();
-            const installed_pv = PkgVersion.parse(installed_version_str);
-            const index_pv = PkgVersion{
-                .version = index_version_str,
-                .revision = @as(u32, entry.revision),
-            };
-
-            const version_outdated = installed_pv.order(index_pv) == .lt;
-            const unlinked = !version_outdated and !isOptLinked(config.prefix, formula.name);
-
-            if (version_outdated or unlinked) {
-                if (!first) try stdout.writeAll(",");
-                try stdout.writeAll("{\"name\":");
-                try writeJsonStr(stdout, formula.name);
-                try stdout.writeAll(",\"installed_version\":");
-                try writeJsonStr(stdout, installed_version_str);
-                var fmt_buf: [128]u8 = undefined;
-                const index_formatted = index_pv.format(&fmt_buf);
-                try stdout.writeAll(",\"latest_version\":");
-                try writeJsonStr(stdout, index_formatted);
-                try stdout.writeAll("}");
-                first = false;
-            }
-        }
-        try stdout.writeAll("]\n");
-        try stdout.flush();
-        return;
-    }
-
     for (installed) |formula| {
-        // Look up this formula in the index.
         const entry = index.lookup(formula.name) orelse continue;
-
-        // Get the latest version string from the index.
         const index_version_str = index.getString(entry.version_offset);
-
-        // Get the installed latest version string.
         const installed_version_str = formula.latestVersion();
-
-        // Build PkgVersion structs for comparison.
         const installed_pv = PkgVersion.parse(installed_version_str);
         const index_pv = PkgVersion{
             .version = index_version_str,
             .revision = @as(u32, entry.revision),
         };
 
-        // If installed < index, this formula is outdated.
-        // Also report formulae whose version matches but are not opt-linked,
-        // matching brew's behavior (unlinked current version = outdated).
         const version_outdated = installed_pv.order(index_pv) == .lt;
-        const unlinked = !version_outdated and !isOptLinked(config.prefix, formula.name);
+        const unlinked = !version_outdated and !isOptLinked(prefix, formula.name);
 
         if (version_outdated or unlinked) {
-            if (verbose) {
-                // Format the index version for display.
-                var fmt_buf: [128]u8 = undefined;
-                const index_formatted = index_pv.format(&fmt_buf);
-                try stdout.print("{s} ({s}) < {s}\n", .{ formula.name, installed_version_str, index_formatted });
+            var fmt_buf: [128]u8 = undefined;
+            const latest_formatted = index_pv.format(&fmt_buf);
+            try out.append(allocator, .{
+                .name = try fmt_arena.dupe(u8, formula.name),
+                .installed_version = try fmt_arena.dupe(u8, installed_version_str),
+                .latest_version = try fmt_arena.dupe(u8, latest_formatted),
+            });
+        }
+    }
+}
+
+/// Collect outdated casks from the caskroom against the cask index.
+/// A cask is outdated when its installed version differs from the cask
+/// index's resolved version. Disabled casks in the index are skipped.
+fn collectOutdatedCasks(
+    allocator: Allocator,
+    cask_idx: *CaskIndex,
+    caskroom: Cellar,
+    out: *std.ArrayList(OutdatedEntry),
+    fmt_arena: Allocator,
+) !void {
+    const installed = caskroom.installedFormulae(allocator);
+    defer {
+        for (installed) |c| {
+            for (c.versions) |v| allocator.free(v);
+            allocator.free(c.versions);
+            allocator.free(c.name);
+        }
+        allocator.free(installed);
+    }
+
+    for (installed) |cask| {
+        const entry = cask_idx.lookup(cask.name) orelse continue;
+        // Skip disabled casks — they have no upgrade target.
+        if ((entry.flags & 2) != 0) continue;
+        const latest = cask_idx.getString(entry.version_offset);
+        if (latest.len == 0) continue;
+        const installed_latest = cask.latestVersion();
+        if (!std.mem.eql(u8, installed_latest, latest)) {
+            try out.append(allocator, .{
+                .name = try fmt_arena.dupe(u8, cask.name),
+                .installed_version = try fmt_arena.dupe(u8, installed_latest),
+                .latest_version = try fmt_arena.dupe(u8, latest),
+            });
+        }
+    }
+}
+
+fn writeJsonEntries(
+    stdout: anytype,
+    entries: []const OutdatedEntry,
+    is_cask: bool,
+    first: *bool,
+) !void {
+    for (entries) |e| {
+        if (!first.*) try stdout.writeAll(",");
+        try stdout.writeAll("{\"name\":");
+        try writeJsonStr(stdout, e.name);
+        try stdout.writeAll(",\"installed_version\":");
+        try writeJsonStr(stdout, e.installed_version);
+        try stdout.writeAll(",\"latest_version\":");
+        try writeJsonStr(stdout, e.latest_version);
+        try stdout.writeAll(",\"cask\":");
+        try stdout.writeAll(if (is_cask) "true" else "false");
+        try stdout.writeAll("}");
+        first.* = false;
+    }
+}
+
+/// Show installed formulae and casks that have a newer version available.
+///
+/// Default: scans both the Cellar (formulae) and Caskroom (casks).
+///
+/// Flags:
+///   --formula / --formulae   only check formulae
+///   --cask    / --casks      only check casks
+///   --verbose / -v           show "name (installed) < latest"
+///   --json                   emit JSON array; each entry has a "cask" bool
+pub fn outdatedCmd(allocator: Allocator, args: []const []const u8, config: Config) anyerror!void {
+    const parsed = parseOutdatedArgs(args);
+    const show_formulae = !parsed.only_casks;
+    const show_casks = !parsed.only_formulae;
+
+    // Arena for entry strings -- freed in one shot at the end.
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const fmt_arena = arena_state.allocator();
+
+    var formulae: std.ArrayList(OutdatedEntry) = .{};
+    defer formulae.deinit(allocator);
+    var casks: std.ArrayList(OutdatedEntry) = .{};
+    defer casks.deinit(allocator);
+
+    if (show_formulae) {
+        var index = try Index.loadOrBuild(allocator, config.cache);
+        _ = &index;
+        const cellar = Cellar.init(config.cellar);
+        try collectOutdatedFormulae(allocator, &index, cellar, config.prefix, &formulae, fmt_arena);
+    }
+
+    if (show_casks) {
+        if (CaskIndex.loadOrBuild(allocator, config.cache)) |idx_val| {
+            var cask_idx = idx_val;
+            const caskroom = Cellar.init(config.caskroom);
+            try collectOutdatedCasks(allocator, &cask_idx, caskroom, &casks, fmt_arena);
+        } else |_| {
+            // No cask index available; skip silently when listing both.
+            // Surface an error only if the user explicitly asked for casks.
+            if (parsed.only_casks) return error.CaskIndexUnavailable;
+        }
+    }
+
+    var buf: [4096]u8 = undefined;
+    var w = std.fs.File.stdout().writer(&buf);
+    const stdout = &w.interface;
+
+    if (parsed.json_output) {
+        try stdout.writeAll("[");
+        var first: bool = true;
+        try writeJsonEntries(stdout, formulae.items, false, &first);
+        try writeJsonEntries(stdout, casks.items, true, &first);
+        try stdout.writeAll("]\n");
+        try stdout.flush();
+        return;
+    }
+
+    // Headers match brew's output when both sections have items.
+    const both = formulae.items.len > 0 and casks.items.len > 0;
+
+    if (formulae.items.len > 0) {
+        if (both) try stdout.writeAll("==> Outdated Formulae\n");
+        for (formulae.items) |e| {
+            if (parsed.verbose) {
+                try stdout.print("{s} ({s}) < {s}\n", .{ e.name, e.installed_version, e.latest_version });
             } else {
-                try stdout.print("{s}\n", .{formula.name});
+                try stdout.print("{s}\n", .{e.name});
+            }
+        }
+    }
+
+    if (casks.items.len > 0) {
+        if (both) try stdout.writeAll("==> Outdated Casks\n");
+        for (casks.items) |e| {
+            if (parsed.verbose) {
+                try stdout.print("{s} ({s}) != {s}\n", .{ e.name, e.installed_version, e.latest_version });
+            } else {
+                try stdout.print("{s}\n", .{e.name});
             }
         }
     }
@@ -134,20 +241,59 @@ pub fn outdatedCmd(allocator: Allocator, args: []const []const u8, config: Confi
 // ---------------------------------------------------------------------------
 
 test "outdatedCmd compiles and has correct signature" {
-    // Smoke test: verifies the function signature is correct and the module compiles.
+    const handler: @import("../dispatch.zig").CommandFn = outdatedCmd;
+    _ = handler;
 }
 
 test "isOptLinked returns true for linked formula" {
-    // Pick a formula that is definitely linked on this system.
-    // /opt/homebrew/opt should contain symlinks for linked formulae.
-    // Use the prefix itself as a known-good accessible path test.
     const result = isOptLinked(Config.default_prefix, ".");
-    // "." resolves to {prefix}/opt/. which should exist if /opt/homebrew/opt exists.
-    // We just verify the function runs without crashing; exact result depends on system.
     _ = result;
 }
 
 test "isOptLinked returns false for nonexistent formula" {
     const result = isOptLinked(Config.default_prefix, "__nonexistent_formula_xyz_42__");
     try std.testing.expect(!result);
+}
+
+test "parseOutdatedArgs defaults" {
+    const args: []const []const u8 = &.{};
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(!p.verbose);
+    try std.testing.expect(!p.json_output);
+    try std.testing.expect(!p.only_formulae);
+    try std.testing.expect(!p.only_casks);
+}
+
+test "parseOutdatedArgs --cask" {
+    const args = &[_][]const u8{"--cask"};
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(p.only_casks);
+    try std.testing.expect(!p.only_formulae);
+}
+
+test "parseOutdatedArgs --casks alias" {
+    const args = &[_][]const u8{"--casks"};
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(p.only_casks);
+}
+
+test "parseOutdatedArgs --formula" {
+    const args = &[_][]const u8{"--formula"};
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(p.only_formulae);
+    try std.testing.expect(!p.only_casks);
+}
+
+test "parseOutdatedArgs --formulae alias" {
+    const args = &[_][]const u8{"--formulae"};
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(p.only_formulae);
+}
+
+test "parseOutdatedArgs combined flags" {
+    const args = &[_][]const u8{ "--verbose", "--json", "--cask" };
+    const p = parseOutdatedArgs(args);
+    try std.testing.expect(p.verbose);
+    try std.testing.expect(p.json_output);
+    try std.testing.expect(p.only_casks);
 }

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -4,6 +4,7 @@ const Config = @import("../config.zig").Config;
 const cellar_mod = @import("../cellar.zig");
 const Cellar = cellar_mod.Cellar;
 const Index = @import("../index.zig").Index;
+const CaskIndex = @import("../cask_index.zig").CaskIndex;
 const PkgVersion = @import("../version.zig").PkgVersion;
 const Output = @import("../output.zig").Output;
 const download = @import("../download.zig");
@@ -16,12 +17,23 @@ const RuntimeDep = tab_mod.RuntimeDep;
 const HttpClient = @import("../http.zig").HttpClient;
 const installCmd = @import("install.zig").installCmd;
 const isPinned = @import("pin.zig").isPinned;
+const cask_mod = @import("../cask.zig");
+const cask_install = @import("../cask_install.zig");
 
 /// An outdated formula pending upgrade.
 const OutdatedFormula = struct {
     name: []const u8,
     installed_version: []const u8,
     index_version: PkgVersion,
+};
+
+/// An outdated cask pending upgrade. Cask versions don't follow PkgVersion
+/// semantics (they may include build metadata after a comma), so we keep them
+/// as raw strings and compare by equality.
+const OutdatedCask = struct {
+    token: []const u8,
+    installed_version: []const u8,
+    latest_version: []const u8,
 };
 
 /// Result of preparing a single package for upgrade (download, extract,
@@ -207,16 +219,24 @@ fn cleanupWorker(ctx: CleanupContext) void {
 ///   bru upgrade              — upgrade all outdated formulae
 ///   bru upgrade <formula>    — upgrade a specific formula
 const ParsedUpgradeArgs = struct {
-    formula_names: std.ArrayList([]const u8),
+    pkg_names: std.ArrayList([]const u8) = .{},
+    only_formulae: bool = false,
+    only_casks: bool = false,
 };
 
 fn parseUpgradeArgs(allocator: Allocator, args: []const []const u8) ParsedUpgradeArgs {
-    var result = ParsedUpgradeArgs{
-        .formula_names = .{},
-    };
+    var result = ParsedUpgradeArgs{};
     for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
+            result.only_casks = true;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
+            result.only_formulae = true;
+            continue;
+        }
         if (arg.len > 0 and arg[0] == '-') continue;
-        result.formula_names.append(allocator, arg) catch {};
+        result.pkg_names.append(allocator, arg) catch {};
     }
     return result;
 }
@@ -225,20 +245,16 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
 
-    // Parse args — collect all non-flag arguments as formula names.
+    // Parse args — collect all non-flag arguments as pkg names; honor
+    // --formula / --cask filter flags.
     var parsed = parseUpgradeArgs(allocator, args);
-    defer parsed.formula_names.deinit(allocator);
+    defer parsed.pkg_names.deinit(allocator);
 
-    // Auto-update: fetch fresh formula data before comparing versions.
+    const want_formulae = !parsed.only_casks;
+    const want_casks = !parsed.only_formulae;
+
+    // Auto-update: fetch fresh formula/cask data before comparing versions.
     {
-        var jws_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const jws_path = std.fmt.bufPrint(&jws_buf, "{s}/api/formula.jws.json", .{config.cache}) catch
-            return error.PathTooLong;
-
-        var idx_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const idx_path = std.fmt.bufPrint(&idx_buf, "{s}/api/formula.bru.idx", .{config.cache}) catch
-            return error.PathTooLong;
-
         var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
         const api_dir = std.fmt.bufPrint(&dir_buf, "{s}/api", .{config.cache}) catch
             return error.PathTooLong;
@@ -247,21 +263,45 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
         var client = HttpClient.init(allocator);
         defer client.deinit();
 
-        if (client.fetch("https://formulae.brew.sh/api/formula.jws.json", jws_path)) {
-            // Fresh data downloaded — delete stale binary index to force rebuild.
-            std.fs.deleteFileAbsolute(idx_path) catch {};
-        } else |_| {}
+        if (want_formulae) {
+            var jws_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const jws_path = std.fmt.bufPrint(&jws_buf, "{s}/api/formula.jws.json", .{config.cache}) catch
+                return error.PathTooLong;
+
+            var idx_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const idx_path = std.fmt.bufPrint(&idx_buf, "{s}/api/formula.bru.idx", .{config.cache}) catch
+                return error.PathTooLong;
+
+            if (client.fetch("https://formulae.brew.sh/api/formula.jws.json", jws_path)) {
+                // Fresh data downloaded — delete stale binary index to force rebuild.
+                std.fs.deleteFileAbsolute(idx_path) catch {};
+            } else |_| {}
+        }
+
+        if (want_casks) {
+            var jws_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const jws_path = std.fmt.bufPrint(&jws_buf, "{s}/api/cask.jws.json", .{config.cache}) catch
+                return error.PathTooLong;
+
+            var idx_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const idx_path = std.fmt.bufPrint(&idx_buf, "{s}/api/cask.bru.idx", .{config.cache}) catch
+                return error.PathTooLong;
+
+            if (client.fetch("https://formulae.brew.sh/api/cask.jws.json", jws_path)) {
+                std.fs.deleteFileAbsolute(idx_path) catch {};
+            } else |_| {}
+        }
     }
 
-    // Load index.
+    // Load formula index (always needed for routing named args).
     var index = try Index.loadOrBuild(allocator, config.cache);
     // Note: do not call index.deinit() -- the index may be mmap'd (from disk)
     // in which case the allocator field is undefined. The process exits after
     // this command so OS reclamation is sufficient.
     _ = &index;
 
-    // Load cellar.
     const cellar = Cellar.init(config.cellar);
+    const caskroom = Cellar.init(config.caskroom);
 
     // Collect outdated formulae to upgrade.
     var to_upgrade: std.ArrayList(OutdatedFormula) = .{};
@@ -273,92 +313,96 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
         to_upgrade.deinit(allocator);
     }
 
-    if (parsed.formula_names.items.len > 0) {
-        // Specific formulae requested — check each if installed and outdated.
-        for (parsed.formula_names.items) |name| {
-            if (!cellar.isInstalled(name)) {
-                err_out.err("{s} is not installed.", .{name});
-                continue;
-            }
+    // Collect outdated casks to upgrade.
+    var casks_to_upgrade: std.ArrayList(OutdatedCask) = .{};
+    defer {
+        for (casks_to_upgrade.items) |item| {
+            allocator.free(item.token);
+            allocator.free(item.installed_version);
+            allocator.free(item.latest_version);
+        }
+        casks_to_upgrade.deinit(allocator);
+    }
 
-            const entry = index.lookup(name) orelse {
-                err_out.err("No available formula with the name \"{s}\".", .{name});
-                err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
-                continue;
-            };
+    if (parsed.pkg_names.items.len > 0) {
+        // Specific packages requested — route each to formula or cask.
+        for (parsed.pkg_names.items) |name| {
+            // --formula forces formula routing; --cask forces cask routing.
+            // Otherwise, check cellar first then caskroom.
+            const is_in_cellar = cellar.isInstalled(name);
+            const is_in_caskroom = caskroom.isInstalled(name);
 
-            const installed_versions = cellar.installedVersions(allocator, name) orelse {
-                err_out.err("{s} is not installed.", .{name});
-                continue;
-            };
-            defer {
-                for (installed_versions) |v| allocator.free(v);
-                allocator.free(installed_versions);
-            }
+            const route_cask = if (parsed.only_casks)
+                true
+            else if (parsed.only_formulae)
+                false
+            else if (is_in_cellar)
+                false
+            else if (is_in_caskroom)
+                true
+            else
+                false; // not installed anywhere; fall through to formula error path
 
-            const installed_latest = installed_versions[installed_versions.len - 1];
-            const installed_pv = PkgVersion.parse(installed_latest);
-            const index_pv = PkgVersion{
-                .version = index.getString(entry.version_offset),
-                .revision = @as(u32, entry.revision),
-            };
-
-            if (installed_pv.order(index_pv) == .lt) {
-                try to_upgrade.append(allocator, .{
-                    .name = try allocator.dupe(u8, name),
-                    .installed_version = try allocator.dupe(u8, installed_latest),
-                    .index_version = index_pv,
-                });
+            if (route_cask) {
+                if (!is_in_caskroom) {
+                    err_out.err("{s} is not installed.", .{name});
+                    continue;
+                }
+                try collectNamedCaskUpgrade(allocator, config, name, &casks_to_upgrade, out, err_out);
             } else {
-                var fmt_buf: [128]u8 = undefined;
-                const current_formatted = installed_pv.format(&fmt_buf);
-                out.print("{s} {s} already up-to-date.\n", .{ name, current_formatted });
+                try collectNamedFormulaUpgrade(allocator, config, &index, cellar, name, &to_upgrade, out, err_out);
             }
         }
     } else {
-        // No specific formula — scan all installed for outdated ones.
-        const installed = cellar.installedFormulae(allocator);
-        defer {
-            for (installed) |f| {
-                for (f.versions) |v| allocator.free(v);
-                allocator.free(f.versions);
-                allocator.free(f.name);
+        if (want_formulae) {
+            const installed = cellar.installedFormulae(allocator);
+            defer {
+                for (installed) |f| {
+                    for (f.versions) |v| allocator.free(v);
+                    allocator.free(f.versions);
+                    allocator.free(f.name);
+                }
+                allocator.free(installed);
             }
-            allocator.free(installed);
+
+            for (installed) |formula| {
+                // Skip pinned formulae when upgrading all.
+                if (isPinned(config.prefix, formula.name)) continue;
+
+                const entry = index.lookup(formula.name) orelse continue;
+
+                const installed_pv = PkgVersion.parse(formula.latestVersion());
+                const index_pv = PkgVersion{
+                    .version = index.getString(entry.version_offset),
+                    .revision = @as(u32, entry.revision),
+                };
+
+                if (installed_pv.order(index_pv) == .lt) {
+                    try to_upgrade.append(allocator, .{
+                        .name = try allocator.dupe(u8, formula.name),
+                        .installed_version = try allocator.dupe(u8, formula.latestVersion()),
+                        .index_version = index_pv,
+                    });
+                }
+            }
         }
 
-        for (installed) |formula| {
-            // Skip pinned formulae when upgrading all.
-            if (isPinned(config.prefix, formula.name)) continue;
-
-            const entry = index.lookup(formula.name) orelse continue;
-
-            const installed_pv = PkgVersion.parse(formula.latestVersion());
-            const index_pv = PkgVersion{
-                .version = index.getString(entry.version_offset),
-                .revision = @as(u32, entry.revision),
-            };
-
-            if (installed_pv.order(index_pv) == .lt) {
-                try to_upgrade.append(allocator, .{
-                    .name = try allocator.dupe(u8, formula.name),
-                    .installed_version = try allocator.dupe(u8, formula.latestVersion()),
-                    .index_version = index_pv,
-                });
-            }
+        if (want_casks) {
+            try collectAllOutdatedCasks(allocator, config, &casks_to_upgrade);
         }
     }
 
     // Nothing to upgrade.
-    if (to_upgrade.items.len == 0) {
+    if (to_upgrade.items.len == 0 and casks_to_upgrade.items.len == 0) {
         out.print("Already up-to-date.\n", .{});
         return;
     }
 
     // Print summary of what will be upgraded.
+    const total = to_upgrade.items.len + casks_to_upgrade.items.len;
     const count_str = try std.fmt.allocPrint(allocator, "Upgrading {d} outdated package{s}", .{
-        to_upgrade.items.len,
-        if (to_upgrade.items.len == 1) "" else "s",
+        total,
+        if (total == 1) "" else "s",
     });
     defer allocator.free(count_str);
     out.section(count_str);
@@ -368,13 +412,36 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
         const new_formatted = item.index_version.format(&fmt_buf);
         out.print("{s} {s} -> {s}\n", .{ item.name, item.installed_version, new_formatted });
     }
+    for (casks_to_upgrade.items) |item| {
+        out.print("{s} {s} -> {s} (cask)\n", .{ item.token, item.installed_version, item.latest_version });
+    }
 
+    if (to_upgrade.items.len > 0) {
+        try runFormulaUpgrade(allocator, config, &index, cellar, to_upgrade.items, out, err_out);
+    }
+
+    if (casks_to_upgrade.items.len > 0) {
+        try runCaskUpgrade(allocator, config, casks_to_upgrade.items, out, err_out);
+    }
+}
+
+/// Run the parallel-prepare + sequential-swap + parallel-cleanup pipeline
+/// for outdated formulae.
+fn runFormulaUpgrade(
+    allocator: Allocator,
+    config: Config,
+    index: *Index,
+    cellar: Cellar,
+    to_upgrade: []const OutdatedFormula,
+    out: Output,
+    err_out: Output,
+) !void {
     // --- Dependency pre-scan: install missing deps before parallel prepare ---
     {
         var all_missing = std.StringHashMap(void).init(allocator);
         defer all_missing.deinit();
 
-        for (to_upgrade.items) |item| {
+        for (to_upgrade) |item| {
             const entry = index.lookup(item.name) orelse continue;
             const dep_names = index.getStringList(allocator, entry.deps_offset) catch continue;
             defer allocator.free(dep_names);
@@ -394,16 +461,16 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
 
     // --- Parallel prepare phase ---
     out.print("\nPreparing {d} package{s}...\n", .{
-        to_upgrade.items.len,
-        if (to_upgrade.items.len == 1) "" else "s",
+        to_upgrade.len,
+        if (to_upgrade.len == 1) "" else "s",
     });
 
-    const results = try allocator.alloc(PrepareResult, to_upgrade.items.len);
+    const results = try allocator.alloc(PrepareResult, to_upgrade.len);
     defer allocator.free(results);
 
     // Per-item arenas kept alive until after swap phase so keg_path pointers
     // in PrepareResult.success remain valid.
-    const arenas = try allocator.alloc(std.heap.ArenaAllocator, to_upgrade.items.len);
+    const arenas = try allocator.alloc(std.heap.ArenaAllocator, to_upgrade.len);
     for (arenas) |*a| a.* = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer {
         for (arenas) |*a| a.deinit();
@@ -416,16 +483,16 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
     }
 
     const prepare_ctx = PrepareContext{
-        .index = &index,
+        .index = index,
         .config = config,
     };
 
     {
         const max_workers = 4;
-        const worker_count = @min(max_workers, to_upgrade.items.len);
+        const worker_count = @min(max_workers, to_upgrade.len);
         var next_index: usize = 0;
         const worker_ctx = PrepareWorkerContext{
-            .items = to_upgrade.items,
+            .items = to_upgrade,
             .results = results,
             .arenas = arenas,
             .next_index = &next_index,
@@ -451,7 +518,7 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
         old_kegs.deinit(allocator);
     }
 
-    for (to_upgrade.items, results) |item, result| {
+    for (to_upgrade, results) |item, result| {
         switch (result) {
             .failure => |f| {
                 err_out.err("Failed to prepare {s}: {s}", .{ item.name, f.err_name });
@@ -522,6 +589,188 @@ pub fn upgradeCmd(allocator: Allocator, args: []const []const u8, config: Config
     }
 }
 
+/// Add a single named formula to the upgrade list after validating it is
+/// installed, present in the index, and actually outdated.
+fn collectNamedFormulaUpgrade(
+    allocator: Allocator,
+    config: Config,
+    index: *Index,
+    cellar: Cellar,
+    name: []const u8,
+    to_upgrade: *std.ArrayList(OutdatedFormula),
+    out: Output,
+    err_out: Output,
+) !void {
+    if (!cellar.isInstalled(name)) {
+        err_out.err("{s} is not installed.", .{name});
+        return;
+    }
+    const entry = index.lookup(name) orelse {
+        err_out.err("No available formula with the name \"{s}\".", .{name});
+        err_out.print("Searched: {s}/api/formula.jws.json\n", .{config.cache});
+        return;
+    };
+    const installed_versions = cellar.installedVersions(allocator, name) orelse {
+        err_out.err("{s} is not installed.", .{name});
+        return;
+    };
+    defer {
+        for (installed_versions) |v| allocator.free(v);
+        allocator.free(installed_versions);
+    }
+
+    const installed_latest = installed_versions[installed_versions.len - 1];
+    const installed_pv = PkgVersion.parse(installed_latest);
+    const index_pv = PkgVersion{
+        .version = index.getString(entry.version_offset),
+        .revision = @as(u32, entry.revision),
+    };
+
+    if (installed_pv.order(index_pv) == .lt) {
+        try to_upgrade.append(allocator, .{
+            .name = try allocator.dupe(u8, name),
+            .installed_version = try allocator.dupe(u8, installed_latest),
+            .index_version = index_pv,
+        });
+    } else {
+        var fmt_buf: [128]u8 = undefined;
+        const current_formatted = installed_pv.format(&fmt_buf);
+        out.print("{s} {s} already up-to-date.\n", .{ name, current_formatted });
+    }
+}
+
+/// Add a single named cask to the upgrade list after validating it is
+/// installed and outdated relative to the cask index.
+fn collectNamedCaskUpgrade(
+    allocator: Allocator,
+    config: Config,
+    name: []const u8,
+    to_upgrade: *std.ArrayList(OutdatedCask),
+    out: Output,
+    err_out: Output,
+) !void {
+    var cask_idx = CaskIndex.loadOrBuild(allocator, config.cache) catch {
+        err_out.err("Cask index unavailable. Run 'bru update' first.", .{});
+        return;
+    };
+
+    const entry = cask_idx.lookup(name) orelse {
+        err_out.err("No available cask with the name \"{s}\".", .{name});
+        return;
+    };
+
+    if ((entry.flags & 2) != 0) {
+        err_out.err("Cask \"{s}\" is disabled.", .{name});
+        return;
+    }
+
+    const caskroom = Cellar.init(config.caskroom);
+    const installed_versions = caskroom.installedVersions(allocator, name) orelse {
+        err_out.err("{s} is not installed.", .{name});
+        return;
+    };
+    defer {
+        for (installed_versions) |v| allocator.free(v);
+        allocator.free(installed_versions);
+    }
+
+    const installed_latest = installed_versions[installed_versions.len - 1];
+    const latest = cask_idx.getString(entry.version_offset);
+    if (latest.len == 0) {
+        err_out.err("Cask \"{s}\" has no version in the index.", .{name});
+        return;
+    }
+
+    if (!std.mem.eql(u8, installed_latest, latest)) {
+        try to_upgrade.append(allocator, .{
+            .token = try allocator.dupe(u8, name),
+            .installed_version = try allocator.dupe(u8, installed_latest),
+            .latest_version = try allocator.dupe(u8, latest),
+        });
+    } else {
+        out.print("{s} {s} already up-to-date.\n", .{ name, installed_latest });
+    }
+}
+
+/// Scan the caskroom and collect every cask whose installed version differs
+/// from the cask index entry. Disabled casks are skipped.
+fn collectAllOutdatedCasks(
+    allocator: Allocator,
+    config: Config,
+    to_upgrade: *std.ArrayList(OutdatedCask),
+) !void {
+    var cask_idx = CaskIndex.loadOrBuild(allocator, config.cache) catch return;
+
+    const caskroom = Cellar.init(config.caskroom);
+    const installed = caskroom.installedFormulae(allocator);
+    defer {
+        for (installed) |c| {
+            for (c.versions) |v| allocator.free(v);
+            allocator.free(c.versions);
+            allocator.free(c.name);
+        }
+        allocator.free(installed);
+    }
+
+    for (installed) |cask| {
+        const entry = cask_idx.lookup(cask.name) orelse continue;
+        if ((entry.flags & 2) != 0) continue;
+        const latest = cask_idx.getString(entry.version_offset);
+        if (latest.len == 0) continue;
+        const installed_latest = cask.latestVersion();
+        if (!std.mem.eql(u8, installed_latest, latest)) {
+            try to_upgrade.append(allocator, .{
+                .token = try allocator.dupe(u8, cask.name),
+                .installed_version = try allocator.dupe(u8, installed_latest),
+                .latest_version = try allocator.dupe(u8, latest),
+            });
+        }
+    }
+}
+
+/// Run a sequential upgrade of the given casks. For each cask: resolve the
+/// per-cask API metadata, then call installCask with upgrade_from set so it
+/// unlinks the old version and removes the old caskroom dir on success.
+fn runCaskUpgrade(
+    allocator: Allocator,
+    config: Config,
+    casks: []const OutdatedCask,
+    out: Output,
+    err_out: Output,
+) !void {
+    out.print("\nUpgrading {d} cask{s}...\n", .{
+        casks.len,
+        if (casks.len == 1) "" else "s",
+    });
+
+    var http_client = HttpClient.init(allocator);
+    defer http_client.deinit();
+
+    for (casks) |item| {
+        const resolved = cask_mod.fetchAndResolveCask(allocator, &http_client, item.token) catch |fetch_err| {
+            err_out.err("Failed to fetch cask metadata for \"{s}\": {s}", .{ item.token, @errorName(fetch_err) });
+            continue;
+        };
+        defer cask_mod.freeResolvedCask(allocator, resolved);
+
+        if (resolved.binaries.len == 0) {
+            err_out.warn("Skipping cask \"{s}\": no CLI binaries (GUI-only cask).", .{item.token});
+            continue;
+        }
+
+        cask_install.installCask(allocator, config, &http_client, resolved, item.installed_version) catch |install_err| {
+            err_out.err("Failed to upgrade cask \"{s}\": {s}", .{ item.token, @errorName(install_err) });
+            continue;
+        };
+
+        // Record state.
+        var state = @import("../state.zig").State.load(allocator);
+        defer state.deinit();
+        state.recordAction("upgrade", item.token, resolved.version, item.installed_version) catch {};
+        state.save() catch {};
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -552,33 +801,66 @@ test "cleanupWorker compiles and has correct signature" {
 test "parseUpgradeArgs extracts single package name" {
     const args = &[_][]const u8{"wget"};
     var parsed = parseUpgradeArgs(std.testing.allocator, args);
-    defer parsed.formula_names.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), parsed.formula_names.items.len);
-    try std.testing.expectEqualStrings("wget", parsed.formula_names.items[0]);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), parsed.pkg_names.items.len);
+    try std.testing.expectEqualStrings("wget", parsed.pkg_names.items[0]);
 }
 
 test "parseUpgradeArgs collects multiple package names" {
     const args = &[_][]const u8{ "wget", "curl", "jq" };
     var parsed = parseUpgradeArgs(std.testing.allocator, args);
-    defer parsed.formula_names.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 3), parsed.formula_names.items.len);
-    try std.testing.expectEqualStrings("wget", parsed.formula_names.items[0]);
-    try std.testing.expectEqualStrings("curl", parsed.formula_names.items[1]);
-    try std.testing.expectEqualStrings("jq", parsed.formula_names.items[2]);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), parsed.pkg_names.items.len);
+    try std.testing.expectEqualStrings("wget", parsed.pkg_names.items[0]);
+    try std.testing.expectEqualStrings("curl", parsed.pkg_names.items[1]);
+    try std.testing.expectEqualStrings("jq", parsed.pkg_names.items[2]);
 }
 
 test "parseUpgradeArgs no arguments returns empty list" {
     const args = &[_][]const u8{};
     var parsed = parseUpgradeArgs(std.testing.allocator, args);
-    defer parsed.formula_names.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 0), parsed.formula_names.items.len);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), parsed.pkg_names.items.len);
 }
 
 test "parseUpgradeArgs skips flags" {
     const args = &[_][]const u8{ "--verbose", "git", "-n", "node" };
     var parsed = parseUpgradeArgs(std.testing.allocator, args);
-    defer parsed.formula_names.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 2), parsed.formula_names.items.len);
-    try std.testing.expectEqualStrings("git", parsed.formula_names.items[0]);
-    try std.testing.expectEqualStrings("node", parsed.formula_names.items[1]);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), parsed.pkg_names.items.len);
+    try std.testing.expectEqualStrings("git", parsed.pkg_names.items[0]);
+    try std.testing.expectEqualStrings("node", parsed.pkg_names.items[1]);
+}
+
+test "parseUpgradeArgs --cask sets only_casks" {
+    const args = &[_][]const u8{ "--cask", "firefox" };
+    var parsed = parseUpgradeArgs(std.testing.allocator, args);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.only_casks);
+    try std.testing.expect(!parsed.only_formulae);
+    try std.testing.expectEqual(@as(usize, 1), parsed.pkg_names.items.len);
+    try std.testing.expectEqualStrings("firefox", parsed.pkg_names.items[0]);
+}
+
+test "parseUpgradeArgs --casks alias" {
+    const args = &[_][]const u8{"--casks"};
+    var parsed = parseUpgradeArgs(std.testing.allocator, args);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.only_casks);
+}
+
+test "parseUpgradeArgs --formula sets only_formulae" {
+    const args = &[_][]const u8{ "--formula", "wget" };
+    var parsed = parseUpgradeArgs(std.testing.allocator, args);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.only_formulae);
+    try std.testing.expect(!parsed.only_casks);
+    try std.testing.expectEqual(@as(usize, 1), parsed.pkg_names.items.len);
+}
+
+test "parseUpgradeArgs --formulae alias" {
+    const args = &[_][]const u8{"--formulae"};
+    var parsed = parseUpgradeArgs(std.testing.allocator, args);
+    defer parsed.pkg_names.deinit(std.testing.allocator);
+    try std.testing.expect(parsed.only_formulae);
 }

--- a/src/help.zig
+++ b/src/help.zig
@@ -10,7 +10,7 @@ pub fn printGeneralHelp(stdout: anytype) !void {
         \\Core commands:
         \\  install    Install a formula or cask
         \\  uninstall  Uninstall a formula
-        \\  upgrade    Upgrade outdated formulae
+        \\  upgrade    Upgrade outdated formulae and casks
         \\  update     Fetch latest formulae data
         \\  search     Search for formulae
         \\  info       Show formula info
@@ -44,7 +44,7 @@ pub fn printGeneralHelp(stdout: anytype) !void {
         \\
         \\Maintenance commands:
         \\  cleanup    Remove old versions and stale downloads
-        \\  outdated   Show outdated formulae
+        \\  outdated   Show outdated formulae and casks
         \\  fetch      Download a formula without installing
         \\  config     Show Homebrew configuration
         \\  log        Show the git log for a formula or cask
@@ -182,9 +182,18 @@ fn getCommandHelp(command: []const u8) ?[]const u8 {
             \\
         },
         .{ "upgrade",
-            \\Usage: bru upgrade [<formula>]
+            \\Usage: bru upgrade [--formula|--cask] [<name> ...]
             \\
-            \\Upgrade outdated formulae. Delegates to brew for the actual upgrade.
+            \\Upgrade outdated formulae and casks.
+            \\
+            \\Options:
+            \\  --formula, --formulae  Only upgrade formulae
+            \\  --cask,    --casks     Only upgrade casks
+            \\
+            \\With no names, upgrades all outdated packages of the selected type
+            \\(both formulae and casks by default). With names, each is auto-routed
+            \\based on whether it lives in the Cellar or Caskroom; force the type
+            \\with --formula or --cask.
             \\
         },
         .{ "update",
@@ -194,12 +203,15 @@ fn getCommandHelp(command: []const u8) ?[]const u8 {
             \\
         },
         .{ "outdated",
-            \\Usage: bru outdated [--json]
+            \\Usage: bru outdated [--verbose] [--json] [--formula|--cask]
             \\
-            \\Show formulae with available upgrades.
+            \\Show formulae and casks with available upgrades.
             \\
             \\Options:
-            \\  --json  Output as JSON
+            \\  --verbose, -v          Show "name (installed) < latest" for each entry
+            \\  --json                 Output as JSON; each entry has a "cask" boolean
+            \\  --formula, --formulae  Only check formulae
+            \\  --cask,    --casks     Only check casks
             \\
         },
         .{ "cleanup",


### PR DESCRIPTION
## Summary
- `bru outdated` now scans the Caskroom and reports outdated casks alongside formulae, with brew-style section headers when both lists have entries.
- `bru upgrade` runs a sequential cask upgrade phase after the existing parallel formula pipeline: download archive → extract to new caskroom version dir → unlink old symlinks → link new → remove old version dir.
- Both commands accept `--cask`/`--casks` and `--formula`/`--formulae` to filter. With no names, both formulae and casks are checked by default.
- Named args auto-route by checking the Cellar first, then the Caskroom; `--cask`/`--formula` forces routing.
- `bru update`-style auto-refresh now fetches cask JWS too when casks will be considered.

## Test plan
- [ ] \`bru outdated\` lists both outdated formulae and casks
- [ ] \`bru outdated --cask\` lists only casks
- [ ] \`bru upgrade\` upgrades all outdated formulae and casks
- [ ] \`bru upgrade <cask-token>\` auto-routes to the cask path
- [ ] \`bru upgrade --cask <token>\` forces cask routing
- [ ] Upgraded cask removes the old caskroom version dir after linking the new one
- [ ] GUI-only casks (no CLI binaries) are skipped with a warning rather than failing