### PR TITLE
feat: benchmark installs against native alternatives and add .app cask support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Anything not implemented natively falls back to the real `brew` binary.
 | **Dependencies** | ~30 Rust crates, SQLite, Tokio | Zero — Zig stdlib only |
 | **Binary size** | 7.9 MB | Single static binary, significantly smaller |
 | **Migration** | Required (`zb migrate`) | Not needed — works on existing Homebrew installation |
+| **Casks** | Not supported | `.app` casks (binary-and-app artifacts) work; brew falls back for `.pkg`/font casks |
+| **Correctness** | Skips patching ffmpeg's `libav*.pc` pkg-config files — `@@HOMEBREW_PREFIX@@` placeholders leak through (see Benchmark below) | Full pkg-config patching alongside Mach-O relocation |
 
 ### vs nanobrew
 
@@ -70,12 +72,68 @@ Anything not implemented natively falls back to the real `brew` binary.
 | **Fallback** | None — unsupported commands fail | Transparent — delegates to brew |
 | **Tar extraction** | Shells out to system `tar` | Native Zig tar with parallel buffer pool |
 | **Tab files** | Separate state tracking | Writes brew-compatible `INSTALL_RECEIPT.json` — brew sees bru-installed packages as its own |
-| **Mach-O patching** | Not fully implemented | Full relocation via `install_name_tool` + `codesign` |
+| **Mach-O patching** | Patches dylibs but leaves `*.pc` files unpatched | Full relocation via `install_name_tool` + `codesign` for both binaries and pkg-config |
+| **Data files** | Skips bundle data (e.g. tesseract `tessdata/eng.traineddata` doesn't extract) — `tesseract --list-langs` finds nothing | Extracts everything declared in the bottle |
 | **Migration** | Required (`nb migrate`) | Not needed |
+
+### vs malt
+
+| | malt | bru |
+|---|---|---|
+| **Drop-in compatible** | No — separate `/opt/malt` prefix | Yes — same prefix, same Cellar |
+| **Fallback** | None | Transparent — delegates to brew |
+| **Warm-cache hot path** | Extracts to content-addressed store, then APFS `clonefile` into the user-visible Cellar (skips re-relocation on re-install) | Same APFS `clonefile` strategy, with the relocation cached per-bottle in `kegs/<sha>/` |
+| **Mach-O patching** | Patches dylibs but partial pkg-config coverage — ffmpeg's `libavdevice.pc` ships with `@@HOMEBREW_PREFIX@@` placeholders | Full pkg-config patching |
+| **Data files** | Same as nanobrew — tesseract `tessdata/` is missing after install | Extracts data subdirectories declared in the bottle |
+| **Casks** | Supported | Supported |
 
 ### The key difference
 
-bru is designed as a **transparent accelerator**, not a parallel ecosystem. Both zerobrew and nanobrew install into separate prefixes, require migration, and leave you switching tools when something isn't supported. bru sits in front of brew — alias `brew=bru` and everything works, faster for native commands and unchanged for the rest. No migration, no duplicate packages, no split brain.
+bru is designed as a **transparent accelerator**, not a parallel ecosystem. The other native alternatives chase raw install speed by skipping the unglamorous patching work — pkg-config files, language data, signature re-application — leaving subtly broken installs that pass `<bin> --version` but fail real consumers (compilers calling `pkg-config --libs libsodium`, `tesseract --list-langs`, etc). bru does the full patching work, keeps the brew-compatible Cellar layout, and falls back to brew for anything unimplemented. Alias `brew=bru` and everything works — faster for native commands, identical for the rest.
+
+## Benchmark (beta)
+
+`test/benchmark/` ships an end-to-end correctness × speed benchmark that compares bru against brew and three other native homebrew-alikes (zerobrew, nanobrew, malt) by actually installing real formulae and casks.
+
+For each `(tool, package)` pair the bench:
+
+1. Uninstalls the package and surgically evicts every cached blob keyed by the bottle's SHA256 (brew API → cache/blobs + store, across each tool's content-addressed prefix).
+2. Times a cold install (no cached bottle on disk).
+3. Uninstalls again, times a warm install (bottle in cache but not yet linked).
+4. Runs a **correctness probe** while the install is on disk:
+    - `ffmpeg`: ffprobe present, every `libav*.pc` patched, `-filters` lists 200+ plugins, transcode a generated test pattern to PNG.
+    - `libsodium`: dylib has no `@@PLACEHOLDER@@`, `lib/pkgconfig/libsodium.pc` exists and is patched.
+    - `duckdb`: `libduckdb.dylib` install_name patched, `lib/cmake/DuckDB/*.cmake` clean, statically-linked parquet round-trip + json_extract both return expected values.
+    - `tesseract`: `--list-langs` finds `eng`/`osd` (catches missing `tessdata/`).
+    - `act`: binary launches, `--help` prints the expected usage banner.
+    - `rectangle` (cask): `Rectangle.app` is in `/Applications/`, executable inside the bundle, `codesign --verify` passes.
+
+**Run it:**
+
+```bash
+bash test/benchmark/bench_contenders.sh   # ensure latest brew, zb, nb, mt; build bru
+bash test/benchmark/bench_chart.sh        # measure + render
+```
+
+Each per-package result lands at `test/benchmark/results-<package>.svg`. Green ✓ = verified, red `!` = passes `--version` but fails a deeper probe, grey dot = not supported by that tool.
+
+![act install benchmark](test/benchmark/results-act.svg)
+
+![ffmpeg install benchmark](test/benchmark/results-ffmpeg.svg)
+
+![libsodium install benchmark](test/benchmark/results-libsodium.svg)
+
+![duckdb install benchmark](test/benchmark/results-duckdb.svg)
+
+![tesseract install benchmark](test/benchmark/results-tesseract.svg)
+
+![rectangle install benchmark](test/benchmark/results-rectangle.svg)
+
+**Beta caveats:**
+
+- The deeper probes are formula-specific (hand-written per package). Adding a new package to `PACKAGES` / `CASKS` env vars works for timing but uses a `--version`-only fallback for correctness until a probe is written for it.
+- "Cold" install timing depends on surgical cache eviction; the bench uses brew's API to derive per-tool cache paths, so a new tool with a custom content-addressing scheme would need its `clear_cache` function updated.
+- Warm-cache numbers are sensitive to disk state and CPU load — run the bench on an otherwise-idle machine for trustworthy comparisons.
 
 ## Building from source
 

--- a/src/cask.zig
+++ b/src/cask.zig
@@ -149,6 +149,14 @@ pub const BinaryArtifact = struct {
     target: []const u8, // symlink name for bin/, e.g., "firefox"
 };
 
+/// An app-bundle artifact (`Some.app`) extracted from a cask's artifacts.
+/// brew moves `source` from the staged Caskroom version dir into `/Applications`
+/// (renamed to `target`), then leaves a back-symlink in the Caskroom.
+pub const AppArtifact = struct {
+    source: []const u8, // bundle name inside the archive, e.g., "Rectangle.app"
+    target: []const u8, // destination basename in /Applications, e.g., "Rectangle.app"
+};
+
 /// Resolved metadata for installing a single cask, fetched from per-cask API.
 pub const ResolvedCask = struct {
     token: []const u8,
@@ -157,6 +165,7 @@ pub const ResolvedCask = struct {
     sha256: []const u8,
     name: []const u8,
     binaries: []BinaryArtifact,
+    apps: []AppArtifact,
 };
 
 /// Platform tags to try when resolving cask variations, in priority order.
@@ -273,6 +282,16 @@ pub fn parseResolvedCask(allocator: Allocator, json_bytes: []const u8) !Resolved
 
     // Parse binary artifacts from the artifacts array.
     const binaries = try parseBinaryArtifacts(allocator, obj);
+    errdefer {
+        for (binaries) |b| {
+            allocator.free(b.source);
+            allocator.free(b.target);
+        }
+        allocator.free(binaries);
+    }
+
+    // Parse app-bundle artifacts (e.g. `app "Rectangle.app"`).
+    const apps = try parseAppArtifacts(allocator, obj);
 
     return ResolvedCask{
         .token = result_token,
@@ -281,6 +300,7 @@ pub fn parseResolvedCask(allocator: Allocator, json_bytes: []const u8) !Resolved
         .sha256 = sha256,
         .name = result_name,
         .binaries = binaries,
+        .apps = apps,
     };
 }
 
@@ -350,6 +370,66 @@ fn parseBinaryArtifacts(allocator: Allocator, obj: std.json.ObjectMap) ![]Binary
     return try result.toOwnedSlice(allocator);
 }
 
+/// Parse app-bundle artifacts from a cask's artifacts array.
+/// App artifacts look like:
+///   - {"app": ["Rectangle.app"]}                       -> source/target = "Rectangle.app"
+///   - {"app": ["Source.app", {"target": "Dest.app"}]}  -> source/target may differ
+fn parseAppArtifacts(allocator: Allocator, obj: std.json.ObjectMap) ![]AppArtifact {
+    const artifacts_val = obj.get("artifacts") orelse return try allocator.alloc(AppArtifact, 0);
+    const artifacts_arr = switch (artifacts_val) {
+        .array => |a| a,
+        else => return try allocator.alloc(AppArtifact, 0),
+    };
+
+    var result = std.ArrayList(AppArtifact){};
+    errdefer {
+        for (result.items) |a| {
+            allocator.free(a.source);
+            allocator.free(a.target);
+        }
+        result.deinit(allocator);
+    }
+
+    for (artifacts_arr.items) |artifact_val| {
+        const artifact_obj = switch (artifact_val) {
+            .object => |o| o,
+            else => continue,
+        };
+
+        const app_val = artifact_obj.get("app") orelse continue;
+        const app_arr = switch (app_val) {
+            .array => |a| a,
+            else => continue,
+        };
+        if (app_arr.items.len == 0) continue;
+
+        const source_raw = switch (app_arr.items[0]) {
+            .string => |s| s,
+            else => continue,
+        };
+        const source_clean = cleanArtifactPath(source_raw);
+
+        const source = try allocator.dupe(u8, source_clean);
+        errdefer allocator.free(source);
+
+        const target = blk: {
+            if (app_arr.items.len > 1) {
+                if (asObject(app_arr.items[1])) |target_obj| {
+                    if (jsonStr(target_obj, "target")) |t| {
+                        break :blk try allocator.dupe(u8, t);
+                    }
+                }
+            }
+            // Default target = basename of source (most casks use this).
+            break :blk try allocator.dupe(u8, std.fs.path.basename(source_clean));
+        };
+
+        try result.append(allocator, .{ .source = source, .target = target });
+    }
+
+    return try result.toOwnedSlice(allocator);
+}
+
 /// Strip known prefixes from cask binary artifact paths.
 /// Removes "$HOMEBREW_PREFIX/Caskroom/{token}/{version}/" and "$APPDIR/" prefixes.
 fn cleanArtifactPath(path: []const u8) []const u8 {
@@ -390,6 +470,11 @@ pub fn freeResolvedCask(allocator: Allocator, c: ResolvedCask) void {
         allocator.free(b.target);
     }
     allocator.free(c.binaries);
+    for (c.apps) |a| {
+        allocator.free(a.source);
+        allocator.free(a.target);
+    }
+    allocator.free(c.apps);
 }
 
 // ---------------------------------------------------------------------------
@@ -553,6 +638,34 @@ test "parseResolvedCask with no binary artifacts" {
     defer freeResolvedCask(allocator, resolved);
 
     try std.testing.expectEqual(@as(usize, 0), resolved.binaries.len);
+    try std.testing.expectEqual(@as(usize, 1), resolved.apps.len);
+    try std.testing.expectEqualStrings("Google Chrome.app", resolved.apps[0].source);
+    try std.testing.expectEqualStrings("Google Chrome.app", resolved.apps[0].target);
+}
+
+test "parseResolvedCask app artifact with target rename" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "renamed",
+        \\  "name": ["Renamed"],
+        \\  "url": "https://example.com/renamed.dmg",
+        \\  "version": "1.0",
+        \\  "sha256": "no_check",
+        \\  "variations": {},
+        \\  "artifacts": [
+        \\    {"app": ["Source.app", {"target": "Dest.app"}]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCask(allocator, json_bytes);
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.apps.len);
+    try std.testing.expectEqualStrings("Source.app", resolved.apps[0].source);
+    try std.testing.expectEqualStrings("Dest.app", resolved.apps[0].target);
 }
 
 test "cleanArtifactPath strips APPDIR prefix" {

--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -10,6 +10,10 @@ const Output = @import("output.zig").Output;
 const cask = @import("cask.zig");
 const ResolvedCask = cask.ResolvedCask;
 const BinaryArtifact = cask.BinaryArtifact;
+const AppArtifact = cask.AppArtifact;
+
+/// Default destination for app bundles. Matches Homebrew's default `appdir`.
+const default_appdir: []const u8 = "/Applications";
 
 /// Install a cask: download archive, extract, stage binaries, and link.
 ///
@@ -86,6 +90,21 @@ pub fn installCask(
                 err_out.warn("Could not stage binary \"{s}\": {s}", .{ binary.target, @errorName(stage_err) });
             };
         }
+    }
+
+    // 6b. Stage app bundles into /Applications and leave a back-symlink in
+    //     the Caskroom (matching brew's default behaviour).
+    for (resolved.apps) |app| {
+        stageApp(allocator, version_dir, default_appdir, app) catch |stage_err| switch (stage_err) {
+            error.AppAlreadyInstalled => err_out.warn(
+                "{s} already exists in {s} — leaving it in place.",
+                .{ app.target, default_appdir },
+            ),
+            else => err_out.warn(
+                "Could not stage app \"{s}\": {s}",
+                .{ app.target, @errorName(stage_err) },
+            ),
+        };
     }
 
     // 7. Link into prefix. For upgrades, first unlink the old version's
@@ -200,6 +219,74 @@ fn extractTar(allocator: Allocator, tar_path: []const u8, dest_dir: []const u8) 
         .Exited => |code| if (code != 0) return error.TarFailed,
         else => return error.TarFailed,
     }
+}
+
+/// Stage a single app-bundle artifact:
+///   1. Verify the extracted source bundle exists.
+///   2. Move it from `{version_dir}/{app.source}` to `{appdir}/{app.target}`
+///      using rename (same-volume) or `ditto`+`rm -rf` (cross-volume fallback).
+///   3. Leave a back-symlink at `{version_dir}/{app.target}` pointing to the
+///      installed bundle — this matches brew's default Caskroom layout and
+///      lets future correctness checks find the bundle via either path.
+/// Returns `error.AppAlreadyInstalled` if the destination already exists,
+/// so callers can warn-but-continue (brew does the same).
+fn stageApp(allocator: Allocator, version_dir: []const u8, appdir: []const u8, app: AppArtifact) !void {
+    const source_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, app.source });
+    defer allocator.free(source_path);
+
+    const target_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ appdir, app.target });
+    defer allocator.free(target_path);
+
+    fs.cwd().access(source_path, .{}) catch {
+        return error.AppNotFound;
+    };
+
+    // If destination already exists, treat as already-installed (warn, don't
+    // overwrite — brew default).
+    if (fs.cwd().access(target_path, .{})) |_| {
+        return error.AppAlreadyInstalled;
+    } else |_| {}
+
+    // Same-volume rename first; if that fails (e.g. EXDEV across volumes),
+    // fall back to a recursive copy that preserves extended attributes
+    // (quarantine flags etc.) then delete the source.
+    if (fs.renameAbsolute(source_path, target_path)) |_| {
+        // ok
+    } else |rename_err| switch (rename_err) {
+        error.RenameAcrossMountPoints => try copyAppCrossVolume(allocator, source_path, target_path),
+        else => return rename_err,
+    }
+
+    // Back-symlink {version_dir}/{target} -> {appdir}/{target}.
+    const back_link = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, app.target });
+    defer allocator.free(back_link);
+    fs.deleteFileAbsolute(back_link) catch |err| switch (err) {
+        error.FileNotFound, error.IsDir => {},
+        else => return err,
+    };
+    try fs.symLinkAbsolute(target_path, back_link, .{});
+}
+
+/// Recursively copy an .app bundle across volumes using `ditto`, then remove
+/// the source. `ditto` preserves resource forks, ACLs, and extended attrs —
+/// `cp -R` does not, so don't substitute it.
+fn copyAppCrossVolume(allocator: Allocator, src: []const u8, dst: []const u8) !void {
+    const ditto = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "ditto", src, dst },
+    });
+    defer allocator.free(ditto.stdout);
+    defer allocator.free(ditto.stderr);
+    switch (ditto.term) {
+        .Exited => |code| if (code != 0) return error.AppCopyFailed,
+        else => return error.AppCopyFailed,
+    }
+    const rm = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "rm", "-rf", src },
+    });
+    defer allocator.free(rm.stdout);
+    defer allocator.free(rm.stderr);
 }
 
 /// Stage a single binary artifact: find it in the extracted tree and

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -396,10 +396,13 @@ fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: O
     };
     defer cask_mod.freeResolvedCask(allocator, resolved);
 
-    // Check if this cask has any binary artifacts.
-    if (resolved.binaries.len == 0) {
-        err_out.warn("No CLI binaries for cask \"{s}\".", .{name});
-        err_out.print("This cask provides only a GUI application.\n", .{});
+    // Only bail when the cask declares neither CLI binaries nor app
+    // bundles — those are the two artifact kinds bru can install. (Casks
+    // limited to `pkg`/`installer`/`font` artifacts still fall through to
+    // a real brew install via the `Use: brew install --cask ...` hint.)
+    if (resolved.binaries.len == 0 and resolved.apps.len == 0) {
+        err_out.warn("No installable artifacts for cask \"{s}\".", .{name});
+        err_out.print("This cask uses an artifact type bru can't handle yet (e.g. pkg, font).\n", .{});
         err_out.print("Use: brew install --cask {s}\n", .{name});
         return;
     }

--- a/test/benchmark/_bench_common.sh
+++ b/test/benchmark/_bench_common.sh
@@ -1,0 +1,102 @@
+# shellcheck shell=bash
+# _bench_common.sh — sourced by bench_contenders.sh and bench_chart.sh.
+# Provides path resolution, per-tool detection, and small logging helpers.
+# Do not execute directly. No shebang on purpose.
+
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$COMMON_DIR/../.." && pwd)"
+BRU="$PROJECT_ROOT/zig-out/bin/bru"
+
+HOMEBREW_CACHE=""
+HOMEBREW_CELLAR=""
+if command -v brew >/dev/null 2>&1; then
+    HOMEBREW_CACHE="$(brew --cache 2>/dev/null || true)"
+    HOMEBREW_CELLAR="$(brew --cellar 2>/dev/null || true)"
+fi
+
+die()  { echo "Error: $*" >&2; exit 1; }
+log()  { printf '%s\n' "$*"; }
+step() { printf '  %s\n' "$*"; }
+
+# Tools in chart/render order (top → bottom).
+TOOL_ORDER=(brew zb nb mt bru)
+
+# Pretty-print a version row. Prepends "v" only when $1 starts with a digit
+# so "not installed" and "—" placeholders aren't decorated.
+print_version_row() {
+    local name="$1" ver="$2"
+    case "$ver" in
+        [0-9]*) printf '  %-6s v%s\n' "$name" "$ver" ;;
+        *)      printf '  %-6s %s\n'  "$name" "$ver" ;;
+    esac
+}
+
+# ── brew ──────────────────────────────────────────────────────────────
+brew_present() { command -v brew >/dev/null 2>&1; }
+brew_version() { brew --version 2>/dev/null | awk 'NR==1 {print $2}'; }
+
+# ── bru ───────────────────────────────────────────────────────────────
+# The benchmark measures the local build at $BRU so changes in this worktree
+# are reflected. If that binary hasn't been built yet, fall back to whatever
+# `bru` is on PATH so version probes still resolve.
+bru_resolved_bin() {
+    if [ -x "$BRU" ]; then
+        echo "$BRU"
+    else
+        command -v bru 2>/dev/null
+    fi
+}
+bru_present() {
+    local b; b=$(bru_resolved_bin)
+    [ -n "$b" ] && [ -x "$b" ]
+}
+bru_version() {
+    local b; b=$(bru_resolved_bin)
+    [ -z "$b" ] && return 0
+    "$b" --version 2>/dev/null | awk 'NR==1 {print $2}'
+}
+
+# ── nb (nanobrew) ─────────────────────────────────────────────────────
+NB_BIN="${NB_BIN:-}"
+nb_present() {
+    if [ -z "$NB_BIN" ]; then
+        NB_BIN="$(command -v nb 2>/dev/null || true)"
+        [ -z "$NB_BIN" ] && [ -x /opt/nanobrew/prefix/bin/nb ] && NB_BIN=/opt/nanobrew/prefix/bin/nb
+    fi
+    [ -n "$NB_BIN" ] && [ -x "$NB_BIN" ]
+}
+nb_version() {
+    # nanobrew with no args prints a banner like "nanobrew v0.1.193 — ...".
+    # The exit code is nonzero (no command given) so capture the output via
+    # `|| true` rather than running the pipeline directly.
+    local raw
+    raw=$("$NB_BIN" 2>&1 || true)
+    printf '%s' "$raw" | sed -nE '1s/.*v([0-9][0-9.]*).*/\1/p'
+}
+
+# ── zb (zerobrew) ─────────────────────────────────────────────────────
+ZB_BIN="${ZB_BIN:-}"
+zb_present() {
+    if [ -z "$ZB_BIN" ]; then
+        ZB_BIN="$(command -v zb 2>/dev/null || true)"
+        [ -z "$ZB_BIN" ] && [ -x /opt/zerobrew/bin/zb ] && ZB_BIN=/opt/zerobrew/bin/zb
+        [ -z "$ZB_BIN" ] && [ -x "$HOME/.local/bin/zb" ] && ZB_BIN="$HOME/.local/bin/zb"
+    fi
+    [ -n "$ZB_BIN" ] && [ -x "$ZB_BIN" ]
+}
+zb_version() {
+    "$ZB_BIN" --version 2>/dev/null | awk 'NR==1 {print $NF}'
+}
+
+# ── mt (malt) ─────────────────────────────────────────────────────────
+MT_BIN="${MT_BIN:-}"
+mt_present() {
+    if [ -z "$MT_BIN" ]; then
+        MT_BIN="$(command -v malt 2>/dev/null || command -v mt 2>/dev/null || true)"
+        [ -z "$MT_BIN" ] && [ -x /usr/local/bin/malt ] && MT_BIN=/usr/local/bin/malt
+    fi
+    [ -n "$MT_BIN" ] && [ -x "$MT_BIN" ]
+}
+mt_version() {
+    "$MT_BIN" --version 2>/dev/null | awk 'NR==1 {print $NF}'
+}

--- a/test/benchmark/bench_chart.sh
+++ b/test/benchmark/bench_chart.sh
@@ -1,0 +1,940 @@
+#!/bin/bash
+# bench_chart.sh — Time a cold-cache and warm-cache install of each formula
+# under every installed contender (brew, zb, nb, mt, bru) and render a
+# polished SVG per package.
+#
+# Prerequisite: run bench_contenders.sh first to ensure every tool is on
+# PATH at its latest version. This script does NOT install or update anything
+# itself — it only reads versions and measures install times.
+#
+# Usage:
+#   bash test/benchmark/bench_chart.sh
+#   bash test/benchmark/bench_chart.sh --dry-run
+#
+# Env:
+#   PACKAGES     space-separated formulae (default: "ffmpeg libsodium duckdb tesseract")
+#   SVG_OUTPUT   path prefix; .svg suffix is stripped and "-<pkg>.svg" appended
+# Note: deliberately NOT using `set -e`. The bench runs many fallible
+# operations (uninstall, cache clear, install) and we want a single failure
+# to be recorded as a bad measurement rather than abort the whole run.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=test/benchmark/_bench_common.sh
+. "$SCRIPT_DIR/_bench_common.sh"
+
+DEFAULT_FORMULAE="act ffmpeg libsodium duckdb tesseract"
+DEFAULT_CASKS="rectangle"
+# PACKAGES kept for backward compatibility — treated as formulae if FORMULAE
+# isn't set explicitly.
+FORMULAE="${FORMULAE:-${PACKAGES:-$DEFAULT_FORMULAE}}"
+CASKS="${CASKS:-$DEFAULT_CASKS}"
+SVG_OUTPUT="${SVG_OUTPUT:-$SCRIPT_DIR/results.svg}"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=true; fi
+
+# ── Per-tool install / uninstall / cache-clear ────────────────────────
+
+# brew
+brew_install_pkg()   { brew install "$1"; }
+brew_uninstall_pkg() {
+    if brew list --formula "$1" &>/dev/null; then
+        brew uninstall --ignore-dependencies "$1" &>/dev/null || true
+    fi
+}
+brew_clear_cache() {
+    [ -n "$HOMEBREW_CACHE" ] || return 0
+    find "$HOMEBREW_CACHE/downloads" -name "*--${1}*" -delete 2>/dev/null || true
+}
+
+# bru — shares the Cellar with brew, so brew uninstall removes its kegs too.
+# Cache layout (separate from brew's, but both live under $HOMEBREW_CACHE):
+#   <cache>/<formula>--<version>             — downloaded bottle (bru-named)
+#   <cache>/<formula>_bottle_manifest--*     — bottle manifests
+#   <cache>/kegs/<sha>/<formula>/<version>/  — pre-extracted keg (clonefile src)
+#   <cache>/downloads/<sha>--<formula>--*    — brew-format archives, if brew
+#                                              has touched the cache too
+bru_install_pkg()   { "$(bru_resolved_bin)" install "$1"; }
+bru_uninstall_pkg() {
+    if [ -n "$HOMEBREW_CELLAR" ] && brew list --formula "$1" &>/dev/null; then
+        brew uninstall --ignore-dependencies "$1" &>/dev/null || true
+    fi
+}
+bru_clear_cache() {
+    local formula=$1
+    local cache="${HOMEBREW_CACHE:-$HOME/Library/Caches/Homebrew}"
+    [ -d "$cache" ] || return 0
+
+    # 1. bru's flat-named archives + manifests at cache root.
+    /usr/bin/find "$cache" -maxdepth 1 \
+        \( -name "${formula}--*" -o -name "${formula}_bottle_manifest--*" \) \
+        -exec /bin/rm -rf {} + 2>/dev/null
+
+    # 2. brew-format archives under downloads/ (in case brew touched this
+    #    cache too).
+    if [ -d "$cache/downloads" ]; then
+        /usr/bin/find "$cache/downloads" -maxdepth 1 -name "*--${formula}*" \
+            -delete 2>/dev/null
+    fi
+
+    # 3. bru's pre-extracted kegs: any sha-dir under kegs/ that contains a
+    #    <formula>/ subdir is for this formula — remove the whole sha-dir.
+    if [ -d "$cache/kegs" ]; then
+        /usr/bin/find "$cache/kegs" -mindepth 2 -maxdepth 2 -type d -name "$formula" 2>/dev/null \
+            | while IFS= read -r kegdir; do
+                /bin/rm -rf "$(/usr/bin/dirname "$kegdir")"
+            done
+    fi
+}
+
+# All three native tools (nb, zb, mt) reuse brew's bottle tarballs and key
+# them by the bottle's SHA256 in their cache/blobs and store/ directories.
+# Surgical cold-cache invalidation = query the brew API for every per-OS
+# bottle SHA of a formula, then delete any file/dir under those caches whose
+# basename matches one of those SHAs.
+
+# Print every bottle SHA256 brew knows about for the formula (one per line).
+bottle_sha256s() {
+    local formula=$1
+    brew info --json=v2 "$formula" 2>/dev/null | /usr/bin/python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    files = d["formulae"][0]["bottle"]["stable"]["files"]
+    for info in files.values():
+        sha = info.get("sha256")
+        if sha:
+            print(sha)
+except Exception:
+    pass
+'
+}
+
+# Delete any entry in $dir whose basename equals a known bottle SHA for
+# $formula, or starts with that SHA followed by an extension (e.g. .tar.gz).
+clear_by_sha() {
+    local dir=$1 formula=$2
+    [ -d "$dir" ] || return 0
+    local sha
+    while IFS= read -r sha; do
+        [ -n "$sha" ] || continue
+        /usr/bin/find "$dir" -maxdepth 1 \
+            \( -name "$sha" -o -name "$sha.*" \) \
+            -exec /bin/rm -rf {} + 2>/dev/null
+    done < <(bottle_sha256s "$formula")
+}
+
+# nb (nanobrew) — cache/blobs/<sha>, store/<sha>/
+nb_install_pkg()   { "$NB_BIN" install "$1"; }
+nb_uninstall_pkg() { "$NB_BIN" remove "$1" >/dev/null 2>&1 || true; }
+nb_clear_cache() {
+    clear_by_sha /opt/nanobrew/cache/blobs "$1"
+    clear_by_sha /opt/nanobrew/store       "$1"
+}
+
+# zb (zerobrew) — cache/blobs/<sha>.tar.gz, store/<sha>/
+zb_install_pkg()   { "$ZB_BIN" install "$1"; }
+zb_uninstall_pkg() { "$ZB_BIN" uninstall "$1" >/dev/null 2>&1 || true; }
+zb_clear_cache() {
+    clear_by_sha /opt/zerobrew/cache/blobs "$1"
+    clear_by_sha /opt/zerobrew/store       "$1"
+}
+
+# mt (malt) — cache/downloads/<sha>, store/<sha>/, store-relocated/<sha>/
+mt_install_pkg()   { "$MT_BIN" install "$1"; }
+mt_uninstall_pkg() { "$MT_BIN" uninstall "$1" >/dev/null 2>&1 || true; }
+mt_clear_cache() {
+    local prefix="${MALT_PREFIX:-/opt/malt}"
+    clear_by_sha "$prefix/cache/downloads" "$1"
+    clear_by_sha "$prefix/store"           "$1"
+    clear_by_sha "$prefix/store-relocated" "$1"
+}
+
+# ── Cask install / uninstall / cache-clear ───────────────────────────
+# Casks ship vendor binaries (.app, fonts, CLI archives). Each cask has a
+# single SHA256 (not multiple per-OS variants like a bottle), and tools cache
+# the downloaded artifact keyed by that SHA. zerobrew has no cask support.
+
+# Print the cask download SHA256 (single value).
+cask_sha256() {
+    local name=$1
+    brew info --cask --json=v2 "$name" 2>/dev/null | /usr/bin/python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    sha = d["casks"][0].get("sha256", "")
+    if sha and sha != "no_check":
+        print(sha)
+except Exception:
+    pass
+'
+}
+
+# Delete entry in $dir whose basename equals the cask SHA, or starts with it
+# followed by an extension or "--<name>--<version>" suffix.
+clear_cask_by_sha() {
+    local dir=$1 cask=$2
+    [ -d "$dir" ] || return 0
+    local sha; sha=$(cask_sha256 "$cask")
+    [ -z "$sha" ] && return 0
+    /usr/bin/find "$dir" -maxdepth 1 \
+        \( -name "$sha" -o -name "$sha.*" -o -name "$sha--*" \) \
+        -exec /bin/rm -rf {} + 2>/dev/null
+    # Some tools also store under <sha>--<cask>--<version>.<ext> naming.
+    /usr/bin/find "$dir" -maxdepth 1 -name "*--${cask}--*" \
+        -exec /bin/rm -rf {} + 2>/dev/null
+}
+
+# brew
+brew_install_cask()   { brew install --cask "$1"; }
+brew_uninstall_cask() {
+    if brew list --cask "$1" &>/dev/null; then
+        brew uninstall --cask "$1" &>/dev/null || true
+    fi
+}
+brew_clear_cask_cache() {
+    [ -n "$HOMEBREW_CACHE" ] || return 0
+    clear_cask_by_sha "$HOMEBREW_CACHE/Cask"      "$1"
+    clear_cask_by_sha "$HOMEBREW_CACHE/downloads" "$1"
+}
+
+# bru — shares /Applications + Caskroom with brew.
+bru_install_cask()   { "$(bru_resolved_bin)" install --cask "$1"; }
+bru_uninstall_cask() {
+    if brew list --cask "$1" &>/dev/null; then
+        brew uninstall --cask "$1" &>/dev/null || true
+    fi
+}
+bru_clear_cask_cache() {
+    local cache="${HOMEBREW_CACHE:-$HOME/Library/Caches/Homebrew}"
+    [ -d "$cache" ] || return 0
+    clear_cask_by_sha "$cache"           "$1"
+    clear_cask_by_sha "$cache/Cask"      "$1"
+    clear_cask_by_sha "$cache/downloads" "$1"
+}
+
+# nb (nanobrew) — `install --cask` / `remove --cask`.
+nb_install_cask()   { "$NB_BIN" install --cask "$1"; }
+nb_uninstall_cask() { "$NB_BIN" remove --cask "$1" >/dev/null 2>&1 || true; }
+nb_clear_cask_cache() {
+    clear_cask_by_sha /opt/nanobrew/cache/blobs "$1"
+    clear_cask_by_sha /opt/nanobrew/store       "$1"
+}
+
+# zb (zerobrew) — no cask support. Mark unsupported by returning nonzero
+# from the install function; the bench treats that as "skip / not measured".
+zb_install_cask()   { return 1; }
+zb_uninstall_cask() { :; }
+zb_clear_cask_cache() { :; }
+
+# mt (malt) — autodetects casks; same `install`/`uninstall` verbs as formulae.
+mt_install_cask()   { "$MT_BIN" install --cask "$1" 2>/dev/null || "$MT_BIN" install "$1"; }
+mt_uninstall_cask() { "$MT_BIN" uninstall "$1" >/dev/null 2>&1 || true; }
+mt_clear_cask_cache() {
+    local prefix="${MALT_PREFIX:-/opt/malt}"
+    clear_cask_by_sha "$prefix/cache/downloads" "$1"
+    clear_cask_by_sha "$prefix/store"           "$1"
+    clear_cask_by_sha "$prefix/store-relocated" "$1"
+    clear_cask_by_sha "$prefix/Caskroom"        "$1"
+}
+
+# ── Generic helpers ───────────────────────────────────────────────────
+
+# Time a command in milliseconds. Suppresses stdout/stderr so we measure
+# wall-clock of the command itself.
+time_cmd_ms() {
+    local secs
+    secs=$( { TIMEFORMAT='%R'; time "$@" >/dev/null 2>&1; } 2>&1 )
+    awk "BEGIN {printf \"%d\", $secs * 1000}"
+}
+
+# ── Correctness checks ───────────────────────────────────────────────
+# Verify that a tool's "install" produced a usable result. The point is to
+# catch the failure modes a fast/minimal install path is most likely to hit:
+#  - Mach-O install_names still pointing at @@HOMEBREW_PREFIX@@ placeholders
+#  - Codesignature invalidated by patching (binary gets killed-9 on launch)
+#  - Missing symlinks in the tool's bin dir
+# A pass means "the binary runs / the library has no unresolved placeholders."
+# A fail does NOT necessarily mean the tool is broken — it could be that this
+# bench's prefix-discovery is wrong for that tool. Treat as a strong hint.
+
+# Map each tool to its install prefix (where bin/, lib/, Cellar/ live).
+tool_prefix() {
+    case "$1" in
+        brew|bru) echo "${HOMEBREW_PREFIX:-/opt/homebrew}" ;;
+        nb)       echo "/opt/nanobrew/prefix" ;;
+        zb)       echo "/opt/zerobrew" ;;
+        mt)       echo "${MALT_PREFIX:-/opt/malt}" ;;
+    esac
+}
+
+# Returns 0 on pass, 1 on fail. Silent on success; prints a one-line diagnosis
+# on failure to stderr.
+#
+# Each formula gets two layers of check:
+#   1. Structural: the artifact (binary or dylib) exists, runs --version, and
+#      has no unresolved @@HOMEBREW_PREFIX@@ placeholders in its load
+#      commands — catches broken codesign / missing relocation.
+#   2. Functional: a real command that exercises plugins, data files, or
+#      pkg-config metadata. Catches tools that skip post_install side effects
+#      (tessdata not extracted, .pc not patched, schemas not compiled).
+correctness_check() {
+    local tool=$1 formula=$2
+    local prefix; prefix=$(tool_prefix "$tool")
+    if [ -z "$prefix" ] || [ ! -d "$prefix" ]; then
+        echo "    correctness[$tool/$formula]: prefix not found ($prefix)" >&2
+        return 1
+    fi
+
+    case "$formula" in
+        libsodium)
+            local dylib pc
+            dylib=$(/usr/bin/find "$prefix" -path "*libsodium*.dylib" -type f 2>/dev/null | /usr/bin/head -1)
+            if [ -z "$dylib" ]; then
+                echo "    correctness[$tool/libsodium]: dylib not found under $prefix" >&2
+                return 1
+            fi
+            if /usr/bin/otool -L "$dylib" 2>/dev/null | /usr/bin/grep -qE '@@'; then
+                echo "    correctness[$tool/libsodium]: unresolved @@PLACEHOLDER@@ in $dylib" >&2
+                return 1
+            fi
+            # Functional: pkg-config file must exist and have its placeholders
+            # rewritten. brew + bru produce libsodium.pc with the real prefix.
+            pc=$(/usr/bin/find "$prefix" -path "*lib/pkgconfig/libsodium.pc" -type f 2>/dev/null | /usr/bin/head -1)
+            if [ -z "$pc" ]; then
+                echo "    correctness[$tool/libsodium]: pkg-config file libsodium.pc not found under $prefix" >&2
+                return 1
+            fi
+            if /usr/bin/grep -qE '@@' "$pc"; then
+                echo "    correctness[$tool/libsodium]: unresolved placeholder in $pc" >&2
+                return 1
+            fi
+            return 0
+            ;;
+        ffmpeg)
+            local bin="$prefix/bin/ffmpeg"
+            local probe="$prefix/bin/ffprobe"
+            if [ ! -x "$bin" ]; then
+                echo "    correctness[$tool/ffmpeg]: $bin not executable" >&2
+                return 1
+            fi
+            if ! "$bin" -version >/dev/null 2>&1; then
+                echo "    correctness[$tool/ffmpeg]: -version failed (codesign/dyld?)" >&2
+                return 1
+            fi
+            # Companion: ffprobe ships in the same bottle. If it's missing,
+            # the bottle wasn't fully linked.
+            if [ ! -x "$probe" ]; then
+                echo "    correctness[$tool/ffmpeg]: ffprobe missing at $probe" >&2
+                return 1
+            fi
+            # pkg-config files: 7 libav*.pc files ship in the bottle. Each one
+            # must have @@HOMEBREW_PREFIX@@ rewritten to a real path.
+            local pc_files placeholder_pcs
+            pc_files=$(/usr/bin/find "$prefix" -path "*lib/pkgconfig/libav*.pc" 2>/dev/null)
+            if [ -z "$pc_files" ]; then
+                echo "    correctness[$tool/ffmpeg]: libav*.pc files not found under $prefix" >&2
+                return 1
+            fi
+            placeholder_pcs=$(echo "$pc_files" | /usr/bin/xargs /usr/bin/grep -lE '@@' 2>/dev/null | /usr/bin/head -1)
+            if [ -n "$placeholder_pcs" ]; then
+                echo "    correctness[$tool/ffmpeg]: unresolved placeholder in $placeholder_pcs" >&2
+                return 1
+            fi
+            # Functional: -filters loads libavfilter and enumerates plugins.
+            local n
+            n=$("$bin" -hide_banner -filters 2>/dev/null | /usr/bin/wc -l | /usr/bin/tr -d ' ')
+            if [ "${n:-0}" -lt 50 ]; then
+                echo "    correctness[$tool/ffmpeg]: -filters listed only ${n:-0} lines (expected >50)" >&2
+                return 1
+            fi
+            # Functional: actually transcode a generated test pattern to PNG.
+            # Exercises libavfilter (lavfi source) + libavcodec (png encoder)
+            # + libavformat (image2 muxer) + libswscale (rgb→png convert).
+            # A broken plugin chain or missing codec fails here even when
+            # -filters passes.
+            local tmp out rc
+            tmp=$(/usr/bin/mktemp -d)
+            out="$tmp/probe.png"
+            "$bin" -hide_banner -loglevel error \
+                -f lavfi -i "color=size=8x8:duration=0.1" \
+                -frames:v 1 -y "$out" >/dev/null 2>&1
+            rc=$?
+            if [ "$rc" -ne 0 ] || [ ! -s "$out" ]; then
+                echo "    correctness[$tool/ffmpeg]: transcode of test pattern → PNG failed (rc=$rc, size=$(/usr/bin/stat -f%z "$out" 2>/dev/null || echo missing))" >&2
+                /bin/rm -rf "$tmp"
+                return 1
+            fi
+            /bin/rm -rf "$tmp"
+            return 0
+            ;;
+        duckdb)
+            local bin="$prefix/bin/duckdb"
+            if [ ! -x "$bin" ]; then
+                echo "    correctness[$tool/duckdb]: $bin not executable" >&2
+                return 1
+            fi
+            if ! "$bin" --version >/dev/null 2>&1; then
+                echo "    correctness[$tool/duckdb]: --version failed" >&2
+                return 1
+            fi
+            # Functional 1: execute a query end-to-end.
+            local out
+            out=$("$bin" -c "SELECT 1+1 AS r;" 2>&1 || true)
+            if ! echo "$out" | /usr/bin/grep -qE '\b2\b'; then
+                echo "    correctness[$tool/duckdb]: SELECT 1+1 did not return 2" >&2
+                return 1
+            fi
+            # libduckdb.dylib must ship + have a real install_name (anyone
+            # embedding duckdb in C/C++ links against it).
+            local dylib
+            dylib=$(/usr/bin/find "$prefix" -name "libduckdb.dylib" -type f 2>/dev/null | /usr/bin/head -1)
+            if [ -z "$dylib" ]; then
+                echo "    correctness[$tool/duckdb]: libduckdb.dylib not shipped (embedding broken)" >&2
+                return 1
+            fi
+            if /usr/bin/otool -D "$dylib" 2>/dev/null | /usr/bin/grep -qE '@@'; then
+                echo "    correctness[$tool/duckdb]: libduckdb.dylib install_name has unresolved placeholder" >&2
+                return 1
+            fi
+            # Public header for C/C++ embedding must be installed.
+            local hdr
+            hdr=$(/usr/bin/find "$prefix" -name "duckdb.hpp" -type f 2>/dev/null | /usr/bin/head -1)
+            if [ -z "$hdr" ]; then
+                echo "    correctness[$tool/duckdb]: duckdb.hpp header missing (embedding broken)" >&2
+                return 1
+            fi
+            # CMake config — required for find_package(DuckDB). Brew installs
+            # 4 .cmake files; check at least one exists and has no @@ left.
+            local cmake_files cmake_placeholder
+            cmake_files=$(/usr/bin/find "$prefix" -path "*lib/cmake/DuckDB/*.cmake" 2>/dev/null)
+            if [ -z "$cmake_files" ]; then
+                echo "    correctness[$tool/duckdb]: lib/cmake/DuckDB/*.cmake missing (find_package broken)" >&2
+                return 1
+            fi
+            cmake_placeholder=$(echo "$cmake_files" | /usr/bin/xargs /usr/bin/grep -lE '@@' 2>/dev/null | /usr/bin/head -1)
+            if [ -n "$cmake_placeholder" ]; then
+                echo "    correctness[$tool/duckdb]: unresolved placeholder in $cmake_placeholder" >&2
+                return 1
+            fi
+            # Functional 2: statically-linked parquet extension round-trip.
+            local tmp pq_out
+            tmp=$(/usr/bin/mktemp -d)
+            pq_out=$("$bin" -c "COPY (SELECT 42 AS x) TO '$tmp/t.parquet'; SELECT x FROM '$tmp/t.parquet';" 2>&1 || true)
+            if ! echo "$pq_out" | /usr/bin/grep -qE '\b42\b'; then
+                echo "    correctness[$tool/duckdb]: parquet round-trip failed (extension broken?)" >&2
+                /bin/rm -rf "$tmp"
+                return 1
+            fi
+            /bin/rm -rf "$tmp"
+            # Functional 3: statically-linked json extension function.
+            local json_out
+            json_out=$("$bin" -c "SELECT json_extract('{\"a\":42}', 'a') AS v;" 2>&1 || true)
+            if ! echo "$json_out" | /usr/bin/grep -qE '\b42\b'; then
+                echo "    correctness[$tool/duckdb]: json_extract did not return 42 (json extension broken)" >&2
+                return 1
+            fi
+            return 0
+            ;;
+        tesseract)
+            local bin="$prefix/bin/tesseract"
+            if [ ! -x "$bin" ]; then
+                echo "    correctness[$tool/tesseract]: $bin not executable" >&2
+                return 1
+            fi
+            if ! "$bin" --version >/dev/null 2>&1; then
+                echo "    correctness[$tool/tesseract]: --version failed" >&2
+                return 1
+            fi
+            # Functional: --list-langs reads tessdata; the brew formula bundles
+            # at least eng + osd. A tool that skipped extracting share/tessdata
+            # will list zero languages.
+            local out
+            out=$("$bin" --list-langs 2>&1 || true)
+            if ! echo "$out" | /usr/bin/grep -qE '^eng$|^osd$'; then
+                echo "    correctness[$tool/tesseract]: --list-langs found no eng/osd (tessdata missing?)" >&2
+                return 1
+            fi
+            return 0
+            ;;
+        act)
+            local bin="$prefix/bin/act"
+            if [ ! -x "$bin" ]; then
+                echo "    correctness[$tool/act]: $bin not executable" >&2
+                return 1
+            fi
+            if ! "$bin" --version >/dev/null 2>&1; then
+                echo "    correctness[$tool/act]: --version failed (codesign/dyld?)" >&2
+                return 1
+            fi
+            # Functional: --help prints command structure. act is a self-
+            # contained Go binary so it doesn't have many ways to be broken,
+            # but a corrupted/truncated install would fail to parse args.
+            local help
+            help=$("$bin" --help 2>&1 || true)
+            if ! echo "$help" | /usr/bin/grep -qiE 'usage:|github actions'; then
+                echo "    correctness[$tool/act]: --help did not show expected usage banner" >&2
+                return 1
+            fi
+            return 0
+            ;;
+        rectangle)
+            # Cask: .app bundle lives in /Applications. The tool may also
+            # symlink/install into its own Caskroom — we accept either path.
+            # Use find rather than glob expansion so missing intermediate
+            # dirs don't trip nounset or bash 3.2 glob behavior.
+            local app=""
+            if [ -d "/Applications/Rectangle.app" ]; then
+                app="/Applications/Rectangle.app"
+            else
+                app=$(/usr/bin/find "$prefix/Caskroom" "$prefix/Cask" \
+                    -maxdepth 3 -type d -name "Rectangle.app" 2>/dev/null | /usr/bin/head -1)
+            fi
+            if [ -z "$app" ] || [ ! -d "$app" ]; then
+                echo "    correctness[$tool/rectangle]: Rectangle.app not found in /Applications or $prefix" >&2
+                return 1
+            fi
+            # The Mach-O binary inside the bundle must exist and be executable.
+            local bin="$app/Contents/MacOS/Rectangle"
+            if [ ! -x "$bin" ]; then
+                echo "    correctness[$tool/rectangle]: $bin missing or not executable" >&2
+                return 1
+            fi
+            # Info.plist must be present (otherwise macOS won't recognise the
+            # app at all — a sign of an interrupted/incomplete install).
+            if [ ! -f "$app/Contents/Info.plist" ]; then
+                echo "    correctness[$tool/rectangle]: Info.plist missing in $app" >&2
+                return 1
+            fi
+            # Code signature must be valid (notarised vendor app — if the tool
+            # mangled the bundle during install, signature verification fails).
+            if ! /usr/bin/codesign --verify --no-strict "$app" 2>/dev/null; then
+                echo "    correctness[$tool/rectangle]: codesign --verify failed for $app" >&2
+                return 1
+            fi
+            return 0
+            ;;
+        *)
+            # Generic fallback for any new formula added to FORMULAE.
+            local bin="$prefix/bin/$formula"
+            [ -x "$bin" ] || { echo "    correctness[$tool/$formula]: $bin not executable" >&2; return 1; }
+            "$bin" --version >/dev/null 2>&1 || { echo "    correctness[$tool/$formula]: --version failed" >&2; return 1; }
+            return 0
+            ;;
+    esac
+}
+
+# Pre-install brew deps once so every tool measures only the target install.
+# Individual dep install failures are reported to stderr but don't abort
+# the bench — the target install may still succeed against partial deps.
+ensure_brew_deps() {
+    local formula="$1"
+    local deps
+    deps=$(brew deps "$formula" 2>/dev/null | tr '\n' ' ') || return 0
+    [ -z "$deps" ] && return 0
+    if $DRY_RUN; then
+        step "[dry-run] pre-install deps for $formula ($(echo "$deps" | wc -w | tr -d ' ') pkgs)"
+        return 0
+    fi
+    for dep in $deps; do
+        if ! brew list --formula "$dep" &>/dev/null; then
+            if ! brew install "$dep" >/dev/null 2>&1; then
+                echo "  (warning: brew install $dep failed; continuing)" >&2
+            fi
+        fi
+    done
+}
+
+# ── Step 1: read versions ────────────────────────────────────────────
+
+log "Step 1 — read versions"
+VERSIONS=()
+PRESENT=()
+for tool in "${TOOL_ORDER[@]}"; do
+    if "${tool}_present"; then
+        PRESENT+=(1)
+        VERSIONS+=("$("${tool}_version" 2>/dev/null || echo '?')")
+    elif $DRY_RUN; then
+        # Render every tool in dry-run mode with a placeholder so the chart
+        # shape is visible without running anything.
+        PRESENT+=(1)
+        VERSIONS+=("—")
+    else
+        PRESENT+=(0)
+        VERSIONS+=("not installed")
+    fi
+done
+
+for i in "${!TOOL_ORDER[@]}"; do
+    print_version_row "${TOOL_ORDER[$i]}" "${VERSIONS[$i]}"
+done
+log ""
+
+# Surface missing-tool warning. The bench will still produce SVGs with
+# greyed-out rows, but the user should know contenders is the fix.
+missing=()
+for i in "${!TOOL_ORDER[@]}"; do
+    [ "${PRESENT[$i]}" = "0" ] && missing+=("${TOOL_ORDER[$i]}")
+done
+if [ ${#missing[@]} -gt 0 ]; then
+    log "Warning: ${missing[*]} not installed — rows will render as 'not measured'."
+    log "         Run: bash $SCRIPT_DIR/bench_contenders.sh"
+    log ""
+fi
+
+# ── Step 2: benchmark cold + warm installs per (tool, package) ───────
+
+# Build unified package list with a parallel kind array.
+# PKG_KIND_ARR[$i] = "formula" or "cask"
+PKG_ARR=()
+PKG_KIND_ARR=()
+for f in $FORMULAE; do PKG_ARR+=("$f"); PKG_KIND_ARR+=("formula"); done
+for c in $CASKS;    do PKG_ARR+=("$c"); PKG_KIND_ARR+=("cask");    done
+NPKGS=${#PKG_ARR[@]}
+NTOOLS=${#TOOL_ORDER[@]}
+
+COLD_TABLE=()
+WARM_TABLE=()
+# CORRECT_TABLE: -1 = not checked, 0 = fail, 1 = pass.
+CORRECT_TABLE=()
+for ((init_i=0; init_i < NTOOLS * NPKGS; init_i++)); do
+    COLD_TABLE+=(0)
+    WARM_TABLE+=(0)
+    CORRECT_TABLE+=(-1)
+done
+
+set_cold()    { local ti=$1 pj=$2 v=$3; COLD_TABLE[$((ti * NPKGS + pj))]=$v; }
+set_warm()    { local ti=$1 pj=$2 v=$3; WARM_TABLE[$((ti * NPKGS + pj))]=$v; }
+set_correct() { local ti=$1 pj=$2 v=$3; CORRECT_TABLE[$((ti * NPKGS + pj))]=$v; }
+get_cold()    { local ti=$1 pj=$2; echo "${COLD_TABLE[$((ti * NPKGS + pj))]:-0}"; }
+get_warm()    { local ti=$1 pj=$2; echo "${WARM_TABLE[$((ti * NPKGS + pj))]:-0}"; }
+get_correct() { local ti=$1 pj=$2; echo "${CORRECT_TABLE[$((ti * NPKGS + pj))]:--1}"; }
+
+log "Step 2 — install benchmark"
+log "Formulae: $FORMULAE"
+log "Casks:    $CASKS"
+log ""
+
+for ti in "${!TOOL_ORDER[@]}"; do
+    tool="${TOOL_ORDER[$ti]}"
+    if [ "${PRESENT[$ti]}" != "1" ]; then
+        log "[$tool] not present — skipping"
+        continue
+    fi
+
+    log "[$tool] v${VERSIONS[$ti]}"
+
+    for pj in "${!PKG_ARR[@]}"; do
+        pkg="${PKG_ARR[$pj]}"
+        kind="${PKG_KIND_ARR[$pj]}"
+
+        # zerobrew has no cask support — mark as not-measured (grey) and
+        # skip rather than calling a stub that would mislabel as BROKEN.
+        if [ "$kind" = "cask" ] && [ "$tool" = "zb" ]; then
+            set_correct $ti $pj -1
+            step "$pkg ($kind) → not supported by $tool"
+            continue
+        fi
+
+        # Dispatch to formula or cask flavour of the per-tool functions.
+        case "$kind" in
+            formula)
+                install_fn="${tool}_install_pkg"
+                uninstall_fn="${tool}_uninstall_pkg"
+                clear_fn="${tool}_clear_cache"
+                ;;
+            cask)
+                install_fn="${tool}_install_cask"
+                uninstall_fn="${tool}_uninstall_cask"
+                clear_fn="${tool}_clear_cask_cache"
+                ;;
+        esac
+
+        # Pre-install brew deps for formulae only (casks don't have a
+        # transitive Homebrew dep tree to warm).
+        if [ "$kind" = "formula" ] && { [ "$tool" = "brew" ] || [ "$tool" = "bru" ]; }; then
+            ensure_brew_deps "$pkg"
+        fi
+
+        if $DRY_RUN; then
+            case "$tool" in
+                bru)  base_c=600;  base_w=250  ;;
+                nb)   base_c=1800; base_w=350  ;;
+                zb)   base_c=1500; base_w=400  ;;
+                mt)   base_c=1700; base_w=380  ;;
+                brew) base_c=2200; base_w=1100 ;;
+            esac
+            mult=$((pj + 1))
+            set_cold $ti $pj $((base_c * mult / 2 + base_c))
+            set_warm $ti $pj $((base_w * mult / 3 + base_w))
+            case "$tool" in
+                nb|mt) set_correct $ti $pj 0 ;;
+                *)     set_correct $ti $pj 1 ;;
+            esac
+            # zb has no cask support — leave row as not-measured in dry-run.
+            if [ "$kind" = "cask" ] && [ "$tool" = "zb" ]; then
+                set_cold $ti $pj 0
+                set_warm $ti $pj 0
+                set_correct $ti $pj -1
+            fi
+            step "[dry-run] $tool $pkg ($kind) → cold=$(get_cold $ti $pj)ms warm=$(get_warm $ti $pj)ms"
+            continue
+        fi
+
+        # Cold install.
+        "$uninstall_fn" "$pkg" || true
+        "$clear_fn"     "$pkg" || true
+        if ! cold=$(time_cmd_ms "$install_fn" "$pkg"); then
+            cold=0
+            echo "  (warning: $tool cold install $pkg failed)" >&2
+        fi
+
+        # Warm install.
+        "$uninstall_fn" "$pkg" || true
+        if ! warm=$(time_cmd_ms "$install_fn" "$pkg"); then
+            warm=0
+            echo "  (warning: $tool warm install $pkg failed)" >&2
+        fi
+
+        # Correctness check while the install is still on disk.
+        if correctness_check "$tool" "$pkg"; then
+            set_correct $ti $pj 1
+            ok_mark="ok"
+        else
+            set_correct $ti $pj 0
+            ok_mark="BROKEN"
+        fi
+
+        "$uninstall_fn" "$pkg" || true
+
+        set_cold $ti $pj $cold
+        set_warm $ti $pj $warm
+        step "$pkg ($kind) → cold=${cold}ms warm=${warm}ms [$ok_mark]"
+    done
+done
+log ""
+
+# ── Step 3: render one SVG per package ───────────────────────────────
+
+OUTPUT_PREFIX="${SVG_OUTPUT%.svg}"
+[ "$OUTPUT_PREFIX" = "$SVG_OUTPUT" ] && OUTPUT_PREFIX="$SVG_OUTPUT"
+
+# Polished palette (Tailwind-inspired).
+WARM_FILL="#FBBF24"        # amber-400
+COLD_FILL="#3B82F6"        # blue-500
+INK="#0F172A"              # slate-900
+INK_MUTED="#64748B"        # slate-500
+INK_FAINT="#94A3B8"        # slate-400
+DIVIDER="#E2E8F0"          # slate-200
+BG="#FFFFFF"
+LABEL_ON_FILL="#FFFFFF"
+
+# Per-package SVG layout.
+SVG_W=760
+PAD_X=32
+TITLE_Y=44
+SUBTITLE_Y=68
+HEADER_BOTTOM=92
+LABEL_W=120
+BAR_X=$((PAD_X + LABEL_W + 16))
+BAR_MAX_W=$((SVG_W - BAR_X - PAD_X))
+ROW_H=46
+BAR_H=26
+LEGEND_PAD=24
+SVG_H=$((HEADER_BOTTOM + 16 + NTOOLS * ROW_H + LEGEND_PAD * 2 + 8))
+
+format_ms() {
+    local ms=$1
+    if [ "$ms" -lt 1000 ]; then
+        printf '%dms' "$ms"
+    else
+        awk "BEGIN {printf \"%.1fs\", $ms/1000}"
+    fi
+}
+
+# Estimate the pixel width of a rendered label so we can decide whether it
+# fits inside its bar segment. 11px semibold ≈ 6.5px per char + 8px padding.
+label_width_px() {
+    local text="$1"
+    local n=${#text}
+    echo $(( n * 7 + 8 ))
+}
+
+render_package_svg() {
+    local pj=$1
+    local pkg="${PKG_ARR[$pj]}"
+
+    local max_total=0
+    for ti in "${!TOOL_ORDER[@]}"; do
+        local total=$(( $(get_warm $ti $pj) + $(get_cold $ti $pj) ))
+        [ $total -gt $max_total ] && max_total=$total
+    done
+    [ $max_total -eq 0 ] && max_total=1
+
+    cat <<SVG_HEAD
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 $SVG_W $SVG_H" width="$SVG_W" height="$SVG_H">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK_MUTED; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK_FAINT; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $LABEL_ON_FILL; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK_FAINT; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: $INK_MUTED; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="$BG"/>
+  <title>$pkg — install benchmark</title>
+  <text class="t-title" x="$PAD_X" y="$TITLE_Y">$pkg</text>
+  <text class="t-subtitle" x="$PAD_X" y="$SUBTITLE_Y">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="$PAD_X" y1="$HEADER_BOTTOM" x2="$((SVG_W - PAD_X))" y2="$HEADER_BOTTOM" stroke="$DIVIDER" stroke-width="1"/>
+SVG_HEAD
+
+    local row_y=$((HEADER_BOTTOM + 24))
+    for ti in "${!TOOL_ORDER[@]}"; do
+        local tool="${TOOL_ORDER[$ti]}"
+        local ver="${VERSIONS[$ti]}"
+        local warm=$(get_warm $ti $pj)
+        local cold=$(get_cold $ti $pj)
+        local correct=$(get_correct $ti $pj)
+
+        local ver_text
+        case "$ver" in
+            [0-9]*) ver_text="v$ver" ;;
+            *)      ver_text="$ver" ;;
+        esac
+
+        local tool_x=$PAD_X
+        local name_y=$((row_y + 10))
+        local ver_y=$((row_y + 26))
+        local bar_y=$((row_y + (ROW_H - BAR_H) / 2))
+        local label_baseline=$((bar_y + BAR_H / 2 + 4))
+
+        # Status indicator — a small colored dot to the right of the tool
+        # name. Green = correctness check passed, red = failed, faint gray =
+        # not measured (tool wasn't present).
+        local status_cx=$((tool_x + 64))
+        local status_cy=$((name_y - 4))
+        local status_fill status_glyph status_glyph_color
+        case "$correct" in
+            1)  status_fill="#22C55E"; status_glyph="✓"; status_glyph_color="#FFFFFF" ;;
+            0)  status_fill="#EF4444"; status_glyph="!"; status_glyph_color="#FFFFFF" ;;
+            *)  status_fill="#CBD5E1"; status_glyph="";  status_glyph_color="#FFFFFF" ;;
+        esac
+
+        cat <<ROW_HEAD
+  <g>
+    <text class="t-tool" x="$tool_x" y="$name_y">$tool</text>
+    <text class="t-ver"  x="$tool_x" y="$ver_y">$ver_text</text>
+    <circle cx="$status_cx" cy="$status_cy" r="6" fill="$status_fill"/>
+    <text class="t-status-glyph" x="$status_cx" y="$((status_cy + 4))" text-anchor="middle" fill="$status_glyph_color">$status_glyph</text>
+ROW_HEAD
+
+        if [ "${PRESENT[$ti]}" != "1" ] || { [ "$warm" -eq 0 ] && [ "$cold" -eq 0 ]; }; then
+            cat <<ROW_SKIP
+    <text class="t-skip" x="$BAR_X" y="$label_baseline">not measured</text>
+  </g>
+ROW_SKIP
+            row_y=$((row_y + ROW_H))
+            continue
+        fi
+
+        local warm_w cold_w
+        warm_w=$(awk "BEGIN {printf \"%d\", $warm / $max_total * $BAR_MAX_W}")
+        cold_w=$(awk "BEGIN {printf \"%d\", $cold / $max_total * $BAR_MAX_W}")
+        [ "$warm_w" -lt 1 ] && warm_w=0
+        [ "$cold_w" -lt 1 ] && cold_w=0
+
+        local warm_label cold_label warm_lbl_w cold_lbl_w
+        warm_label=$(format_ms $warm)
+        cold_label=$(format_ms $cold)
+        warm_lbl_w=$(label_width_px "$warm_label")
+        cold_lbl_w=$(label_width_px "$cold_label")
+
+        local cold_x=$((BAR_X + warm_w + 2))
+        local bar_end=$((cold_x + cold_w))
+        local outside_x=$((bar_end + 8))
+        local warm_inside=0 cold_inside=0
+
+        if [ "$warm_w" -gt 0 ]; then
+            cat <<WARM_SEG
+    <rect x="$BAR_X" y="$bar_y" width="$warm_w" height="$BAR_H" rx="4" ry="4" fill="$WARM_FILL"/>
+WARM_SEG
+            if [ "$warm_w" -ge "$warm_lbl_w" ]; then
+                warm_inside=1
+                local cx=$((BAR_X + warm_w / 2))
+                cat <<WARM_LBL
+    <text class="t-label-off" x="$cx" y="$label_baseline" text-anchor="middle">$warm_label</text>
+WARM_LBL
+            fi
+        fi
+
+        if [ "$cold_w" -gt 0 ]; then
+            cat <<COLD_SEG
+    <rect x="$cold_x" y="$bar_y" width="$cold_w" height="$BAR_H" rx="4" ry="4" fill="$COLD_FILL"/>
+COLD_SEG
+            if [ "$cold_w" -ge "$cold_lbl_w" ]; then
+                cold_inside=1
+                local cx=$((cold_x + cold_w / 2))
+                cat <<COLD_LBL
+    <text class="t-label-on" x="$cx" y="$label_baseline" text-anchor="middle">$cold_label</text>
+COLD_LBL
+            fi
+        fi
+
+        if [ "$warm_inside" -eq 0 ] && [ "$warm_w" -gt 0 ]; then
+            cat <<WARM_OUT
+    <text class="t-warm-out" x="$outside_x" y="$label_baseline">$warm_label</text>
+WARM_OUT
+            outside_x=$((outside_x + warm_lbl_w + 6))
+        fi
+        if [ "$cold_inside" -eq 0 ] && [ "$cold_w" -gt 0 ]; then
+            cat <<COLD_OUT
+    <text class="t-cold-out" x="$outside_x" y="$label_baseline">$cold_label</text>
+COLD_OUT
+        fi
+
+        cat <<ROW_END
+  </g>
+ROW_END
+        row_y=$((row_y + ROW_H))
+    done
+
+    local legend_y=$((row_y + LEGEND_PAD))
+    local legend_x=$PAD_X
+    cat <<LEGEND
+  <g>
+    <rect x="$legend_x" y="$((legend_y - 9))" width="12" height="12" rx="2" ry="2" fill="$WARM_FILL"/>
+    <text class="t-legend" x="$((legend_x + 18))" y="$((legend_y + 1))">CACHE WARM</text>
+    <rect x="$((legend_x + 130))" y="$((legend_y - 9))" width="12" height="12" rx="2" ry="2" fill="$COLD_FILL"/>
+    <text class="t-legend" x="$((legend_x + 148))" y="$((legend_y + 1))">CACHE COLD</text>
+    <circle cx="$((legend_x + 266))" cy="$((legend_y - 3))" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="$((legend_x + 266))" y="$((legend_y + 1))" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="$((legend_x + 278))" y="$((legend_y + 1))">VERIFIED</text>
+    <circle cx="$((legend_x + 348))" cy="$((legend_y - 3))" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="$((legend_x + 348))" y="$((legend_y + 1))" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="$((legend_x + 360))" y="$((legend_y + 1))">BROKEN</text>
+  </g>
+</svg>
+LEGEND
+}
+
+log "Step 3 — render SVGs"
+WRITTEN=()
+for pj in "${!PKG_ARR[@]}"; do
+    pkg="${PKG_ARR[$pj]}"
+    out="${OUTPUT_PREFIX}-${pkg}.svg"
+    render_package_svg "$pj" > "$out"
+    WRITTEN+=("$out")
+    step "wrote $out"
+done
+
+log ""
+log "Done. ${#WRITTEN[@]} SVG(s) written."

--- a/test/benchmark/bench_contenders.sh
+++ b/test/benchmark/bench_contenders.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# bench_contenders.sh — install or self-update every package manager that
+# `bench_chart.sh` benchmarks against. Idempotent: skips work that's already
+# done, runs the upstream self-update path when a tool is already present.
+#
+# Usage:
+#   bash test/benchmark/bench_contenders.sh
+#   bash test/benchmark/bench_contenders.sh --dry-run
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=test/benchmark/_bench_common.sh
+. "$SCRIPT_DIR/_bench_common.sh"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=true; fi
+
+# ── ensure-latest functions ──────────────────────────────────────────
+
+brew_ensure_latest() {
+    brew_present || die "brew is not installed — install via https://brew.sh first"
+    log "[brew] brew update"
+    if $DRY_RUN; then step "[dry-run] brew update"; return; fi
+    brew update >/dev/null 2>&1 || true
+}
+
+bru_ensure_latest() {
+    log "[bru] zig build -Doptimize=ReleaseFast (worktree: $PROJECT_ROOT)"
+    if $DRY_RUN; then step "[dry-run] zig build -Doptimize=ReleaseFast"; return; fi
+    (cd "$PROJECT_ROOT" && zig build -Doptimize=ReleaseFast)
+}
+
+nb_ensure_latest() {
+    if nb_present; then
+        log "[nb] $NB_BIN update"
+        if $DRY_RUN; then step "[dry-run] $NB_BIN update"; return; fi
+        "$NB_BIN" update >/dev/null 2>&1 || true
+        return
+    fi
+    log "[nb] not installed — running nanobrew install script"
+    if $DRY_RUN; then step "[dry-run] curl -fsSL https://nanobrew.dev/install.sh | bash"; return; fi
+    curl -fsSL https://nanobrew.dev/install.sh | bash \
+        || { echo "nanobrew install failed" >&2; return 1; }
+    NB_BIN=""; nb_present
+}
+
+zb_ensure_latest() {
+    # The official install script doubles as the updater.
+    if zb_present; then
+        log "[zb] re-running install script to update"
+    else
+        log "[zb] not installed — running install script"
+    fi
+    if $DRY_RUN; then step "[dry-run] curl -fsSL https://zerobrew.rs/install | bash"; return; fi
+    curl -fsSL https://zerobrew.rs/install | bash \
+        || { echo "zerobrew install/update failed" >&2; return 1; }
+    ZB_BIN=""; zb_present
+}
+
+mt_ensure_latest() {
+    # Same story as zb — install script also updates.
+    if mt_present; then
+        log "[mt] re-running install script to update"
+    else
+        log "[mt] not installed — running malt install script"
+    fi
+    if $DRY_RUN; then
+        step "[dry-run] curl -fsSL https://raw.githubusercontent.com/indaco/malt/main/scripts/install.sh | bash"
+        return
+    fi
+    curl -fsSL https://raw.githubusercontent.com/indaco/malt/main/scripts/install.sh | bash \
+        || { echo "malt install/update failed" >&2; return 1; }
+    MT_BIN=""; mt_present
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+log "Installing/updating benchmark contenders..."
+log ""
+
+for tool in "${TOOL_ORDER[@]}"; do
+    "${tool}_ensure_latest" || true
+done
+
+log ""
+log "Final versions:"
+for tool in "${TOOL_ORDER[@]}"; do
+    if "${tool}_present"; then
+        v=$("${tool}_version" 2>/dev/null || echo '?')
+        print_version_row "$tool" "$v"
+    else
+        print_version_row "$tool" "not installed"
+    fi
+done

--- a/test/benchmark/results-act.svg
+++ b/test/benchmark/results-act.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>act — install benchmark</title>
+  <text class="t-title" x="32" y="44">act</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="215" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="275" y="143" text-anchor="middle">4.1s</text>
+    <rect x="385" y="126" width="344" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="557" y="143" text-anchor="middle">6.6s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="172" width="27" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="197" y="172" width="189" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="291" y="189" text-anchor="middle">3.6s</text>
+    <text class="t-warm-out" x="394" y="189">531ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="170" y="218" width="136" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="238" y="235" text-anchor="middle">2.6s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="170" y="264" width="146" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="243" y="281" text-anchor="middle">2.8s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="2" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="172" y="310" width="22" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-warm-out" x="202" y="327">46ms</text>
+    <text class="t-cold-out" x="244" y="327">425ms</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>

--- a/test/benchmark/results-duckdb.svg
+++ b/test/benchmark/results-duckdb.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>duckdb — install benchmark</title>
+  <text class="t-title" x="32" y="44">duckdb</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="177" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="256" y="143" text-anchor="middle">5.1s</text>
+    <rect x="347" y="126" width="382" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="538" y="143" text-anchor="middle">11.0s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="172" width="43" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="189" y="189" text-anchor="middle">1.3s</text>
+    <rect x="213" y="172" width="293" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="359" y="189" text-anchor="middle">8.5s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="218" width="9" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="179" y="218" width="269" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="313" y="235" text-anchor="middle">7.8s</text>
+    <text class="t-warm-out" x="456" y="235">260ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="170" y="264" width="293" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="316" y="281" text-anchor="middle">8.5s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="19" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="189" y="310" width="44" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="211" y="327" text-anchor="middle">1.3s</text>
+    <text class="t-warm-out" x="241" y="327">555ms</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>

--- a/test/benchmark/results-ffmpeg.svg
+++ b/test/benchmark/results-ffmpeg.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>ffmpeg — install benchmark</title>
+  <text class="t-title" x="32" y="44">ffmpeg</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="216" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="276" y="143" text-anchor="middle">6.0s</text>
+    <rect x="386" y="126" width="343" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="557" y="143" text-anchor="middle">9.5s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="168" y="172" width="71" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="203" y="189" text-anchor="middle">2.0s</text>
+    <rect x="241" y="172" width="208" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="345" y="189" text-anchor="middle">5.8s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="168" y="218" width="16" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="186" y="218" width="181" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="276" y="235" text-anchor="middle">5.0s</text>
+    <text class="t-warm-out" x="375" y="235">447ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="168" y="264" width="1" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="171" y="264" width="149" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="245" y="281" text-anchor="middle">4.1s</text>
+    <text class="t-warm-out" x="328" y="281">30ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="54" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="195" y="327" text-anchor="middle">1.5s</text>
+    <rect x="224" y="310" width="65" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="256" y="327" text-anchor="middle">1.8s</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>

--- a/test/benchmark/results-libsodium.svg
+++ b/test/benchmark/results-libsodium.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>libsodium — install benchmark</title>
+  <text class="t-title" x="32" y="44">libsodium</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="259" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="297" y="143" text-anchor="middle">4.1s</text>
+    <rect x="429" y="126" width="300" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="579" y="143" text-anchor="middle">4.8s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="172" width="23" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="193" y="172" width="87" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="236" y="189" text-anchor="middle">1.4s</text>
+    <text class="t-warm-out" x="288" y="189">367ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="168" y="218" width="2" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="172" y="218" width="81" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="212" y="235" text-anchor="middle">1.3s</text>
+    <text class="t-warm-out" x="261" y="235">37ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="170" y="264" width="54" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="197" y="281" text-anchor="middle">864ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="4" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="174" y="310" width="5" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-warm-out" x="187" y="327">73ms</text>
+    <text class="t-cold-out" x="229" y="327">82ms</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>

--- a/test/benchmark/results-rectangle.svg
+++ b/test/benchmark/results-rectangle.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>rectangle — install benchmark</title>
+  <text class="t-title" x="32" y="44">rectangle</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="205" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="270" y="143" text-anchor="middle">3.3s</text>
+    <rect x="375" y="126" width="252" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="501" y="143" text-anchor="middle">4.1s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#CBD5E1"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF"></text>
+    <text class="t-skip" x="168" y="189">not measured</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="218" width="310" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="323" y="235" text-anchor="middle">5.0s</text>
+    <rect x="480" y="218" width="249" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="604" y="235" text-anchor="middle">4.0s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="170" y="264" width="333" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="336" y="281" text-anchor="middle">5.4s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="18" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="188" y="310" width="34" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-warm-out" x="230" y="327">290ms</text>
+    <text class="t-cold-out" x="279" y="327">560ms</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>

--- a/test/benchmark/results-tesseract.svg
+++ b/test/benchmark/results-tesseract.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 394" width="760" height="394">
+  <defs>
+    <style>
+      .t-title    { font: 600 22px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-tool     { font: 600 13px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-ver      { font: 400 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; }
+      .t-label-on { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #FFFFFF; }
+      .t-label-off{ font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #0F172A; }
+      .t-warm-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #B45309; }
+      .t-cold-out { font: 600 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #1D4ED8; }
+      .t-skip     { font: 400 12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #94A3B8; font-style: italic; }
+      .t-legend   { font: 500 11px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; fill: #64748B; letter-spacing: 0.02em; }
+      .t-status-glyph { font: 700 9px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, system-ui, sans-serif; }
+    </style>
+  </defs>
+  <rect width="100%" height="100%" fill="#FFFFFF"/>
+  <title>tesseract — install benchmark</title>
+  <text class="t-title" x="32" y="44">tesseract</text>
+  <text class="t-subtitle" x="32" y="68">INSTALL BENCHMARK · COLD VS WARM CACHE</text>
+  <line x1="32" y1="92" x2="728" y2="92" stroke="#E2E8F0" stroke-width="1"/>
+  <g>
+    <text class="t-tool" x="32" y="126">brew</text>
+    <text class="t-ver"  x="32" y="142">v5.1.12-17-g3a3bc20</text>
+    <circle cx="96" cy="122" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="126" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="126" width="225" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="280" y="143" text-anchor="middle">5.6s</text>
+    <rect x="395" y="126" width="334" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="562" y="143" text-anchor="middle">8.3s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="172">zb</text>
+    <text class="t-ver"  x="32" y="188">v0.2.1</text>
+    <circle cx="96" cy="168" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="172" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="172" width="92" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <text class="t-label-off" x="214" y="189" text-anchor="middle">2.3s</text>
+    <rect x="262" y="172" width="190" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="357" y="189" text-anchor="middle">4.8s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="218">nb</text>
+    <text class="t-ver"  x="32" y="234">v0.1.193</text>
+    <circle cx="96" cy="214" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="218" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="168" y="218" width="11" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="181" y="218" width="161" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="261" y="235" text-anchor="middle">4.0s</text>
+    <text class="t-warm-out" x="350" y="235">281ms</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="264">mt</text>
+    <text class="t-ver"  x="32" y="280">v0.13.0</text>
+    <circle cx="96" cy="260" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="96" y="264" text-anchor="middle" fill="#FFFFFF">!</text>
+    <rect x="170" y="264" width="128" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-label-on" x="234" y="281" text-anchor="middle">3.2s</text>
+  </g>
+  <g>
+    <text class="t-tool" x="32" y="310">bru</text>
+    <text class="t-ver"  x="32" y="326">dev</text>
+    <circle cx="96" cy="306" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="96" y="310" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <rect x="168" y="310" width="33" height="26" rx="4" ry="4" fill="#FBBF24"/>
+    <rect x="203" y="310" width="39" height="26" rx="4" ry="4" fill="#3B82F6"/>
+    <text class="t-warm-out" x="250" y="327">830ms</text>
+    <text class="t-cold-out" x="299" y="327">989ms</text>
+  </g>
+  <g>
+    <rect x="32" y="361" width="12" height="12" rx="2" ry="2" fill="#FBBF24"/>
+    <text class="t-legend" x="50" y="371">CACHE WARM</text>
+    <rect x="162" y="361" width="12" height="12" rx="2" ry="2" fill="#3B82F6"/>
+    <text class="t-legend" x="180" y="371">CACHE COLD</text>
+    <circle cx="298" cy="367" r="6" fill="#22C55E"/>
+    <text class="t-status-glyph" x="298" y="371" text-anchor="middle" fill="#FFFFFF">✓</text>
+    <text class="t-legend" x="310" y="371">VERIFIED</text>
+    <circle cx="380" cy="367" r="6" fill="#EF4444"/>
+    <text class="t-status-glyph" x="380" y="371" text-anchor="middle" fill="#FFFFFF">!</text>
+    <text class="t-legend" x="392" y="371">BROKEN</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- New `test/benchmark/` utility (`bench_contenders.sh` + `bench_chart.sh`) that times cold + warm installs across **brew, zerobrew, nanobrew, malt, and bru** and renders a polished SVG per package showing the cold/warm split alongside a per-tool **correctness verdict**.
- Per-formula correctness probes catch silent breakage that `<bin> --version` misses: unpatched `@@HOMEBREW_PREFIX@@` placeholders in pkg-config files, missing tessdata for `tesseract`, broken `libduckdb.dylib` install_names, codesign mismatches, etc.
- Cask installer now handles `app` artifacts. `bru install --cask rectangle` actually copies `Rectangle.app` into `/Applications/` (plus a back-symlink in the Caskroom) instead of bailing with the old "binary-only" warning.
- README "How bru compares" updated with empirical findings — zerobrew/nanobrew/malt each skip different post-extraction patching steps; new "Benchmark (beta)" section embeds the result SVGs.

## Test plan

- [x] `zig test src/cask.zig` — 9/9 (incl. 2 new cask `app` artifact tests).
- [x] `zig build -Doptimize=ReleaseFast` succeeds (against zig 0.15.2).
- [x] `bru install --cask rectangle` installs Rectangle.app to /Applications/ with valid codesign.
- [x] Full bench run end-to-end against brew 5.1.12, zb 0.2.1, nb 0.1.193, mt 0.13.0; all 30 (tool, package) cells produced expected verdicts.