### PR TITLE
fix: correct cask upgrade silent failures and version drift

### DIFF
--- a/src/cask.zig
+++ b/src/cask.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 const HttpClient = @import("http.zig").HttpClient;
@@ -19,7 +20,16 @@ pub const CaskInfo = struct {
 
 /// Parse a JSON array of cask objects into a slice of CaskInfo.
 /// The caller owns the returned slice and must free each entry with freeCask.
+/// Uses the current machine's macOS for variation resolution.
 pub fn parseCaskJson(allocator: Allocator, json_bytes: []const u8) ![]CaskInfo {
+    var tag_buf: [64]u8 = undefined;
+    const tag = currentMacOSVariationTag(&tag_buf);
+    return parseCaskJsonWithTag(allocator, json_bytes, tag);
+}
+
+/// Same as parseCaskJson but with the variation tag passed explicitly.
+/// Useful for tests and for callers that want to resolve for a non-current OS.
+pub fn parseCaskJsonWithTag(allocator: Allocator, json_bytes: []const u8, variation_tag: []const u8) ![]CaskInfo {
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{
         .allocate = .alloc_always,
     });
@@ -44,15 +54,30 @@ pub fn parseCaskJson(allocator: Allocator, json_bytes: []const u8) ![]CaskInfo {
             else => continue,
         };
 
-        const info = parseOneCask(allocator, obj) catch continue;
+        const info = parseOneCask(allocator, obj, variation_tag) catch continue;
         result.appendAssumeCapacity(info);
     }
 
     return try result.toOwnedSlice(allocator);
 }
 
-/// Parse a single cask JSON object into a CaskInfo.
-fn parseOneCask(allocator: Allocator, obj: std.json.ObjectMap) !CaskInfo {
+/// Parse a single cask JSON object's bytes into a CaskInfo, applying the given
+/// variation tag. Public so tests can drive parseOneCask directly.
+pub fn parseSingleCaskJson(allocator: Allocator, json_bytes: []const u8, variation_tag: []const u8) !CaskInfo {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidJson,
+    };
+    return parseOneCask(allocator, obj, variation_tag);
+}
+
+/// Parse a single cask JSON object into a CaskInfo. Applies the platform
+/// variation override iff `variation_tag` is present in `variations`.
+fn parseOneCask(allocator: Allocator, obj: std.json.ObjectMap, variation_tag: []const u8) !CaskInfo {
     const token = try allocator.dupe(u8, jsonStr(obj, "token") orelse return error.MissingField);
     errdefer allocator.free(token);
 
@@ -81,13 +106,23 @@ fn parseOneCask(allocator: Allocator, obj: std.json.ObjectMap) !CaskInfo {
     const homepage = try allocator.dupe(u8, jsonStr(obj, "homepage") orelse "");
     errdefer allocator.free(homepage);
 
-    const version = try allocator.dupe(u8, jsonStr(obj, "version") orelse "");
+    // Start from top-level, then override with the current-OS variation iff present.
+    var version_src: []const u8 = jsonStr(obj, "version") orelse "";
+    var url_src: []const u8 = jsonStr(obj, "url") orelse "";
+    var sha256_src: []const u8 = jsonStr(obj, "sha256") orelse "";
+    if (variationOverrideObject(obj, variation_tag)) |tag_obj| {
+        if (jsonStr(tag_obj, "version")) |v| version_src = v;
+        if (jsonStr(tag_obj, "url")) |u| url_src = u;
+        if (jsonStr(tag_obj, "sha256")) |s| sha256_src = s;
+    }
+
+    const version = try allocator.dupe(u8, version_src);
     errdefer allocator.free(version);
 
-    const url = try allocator.dupe(u8, jsonStr(obj, "url") orelse "");
+    const url = try allocator.dupe(u8, url_src);
     errdefer allocator.free(url);
 
-    const sha256 = try allocator.dupe(u8, jsonStr(obj, "sha256") orelse "");
+    const sha256 = try allocator.dupe(u8, sha256_src);
     // No errdefer needed for the last allocation before the return.
 
     const deprecated = jsonBool(obj, "deprecated") orelse false;
@@ -168,30 +203,53 @@ pub const ResolvedCask = struct {
     apps: []AppArtifact,
 };
 
-/// Platform tags to try when resolving cask variations, in priority order.
-/// Tries the most specific first (arch + OS version), then falls back to
-/// less specific tags. The first match wins.
-fn platformVariationTags() []const []const u8 {
-    const arch = @import("builtin").target.cpu.arch;
-
-    if (arch == .aarch64) {
-        return &.{
-            "arm64_tahoe",
-            "arm64_sequoia",
-            "arm64_sonoma",
-            "arm64_ventura",
-            "arm64_monterey",
-            "arm64_big_sur",
-        };
-    }
-    return &.{
-        "tahoe",
-        "sequoia",
-        "sonoma",
-        "ventura",
-        "monterey",
-        "big_sur",
+/// Map a Darwin kernel major version and CPU arch to the Homebrew cask
+/// variation tag for the user's actual macOS. Returns "" when the kernel
+/// release is unknown — callers treat empty as "no variation, use top-level".
+///
+/// Darwin → macOS mapping:
+///   25 → Tahoe (macOS 26)        22 → Ventura (13)
+///   24 → Sequoia (15)            21 → Monterey (12)
+///   23 → Sonoma (14)             20 → Big Sur (11)
+fn darwinReleaseToVariationTag(major: u32, arch: std.Target.Cpu.Arch, buf: []u8) []const u8 {
+    const name: []const u8 = switch (major) {
+        25 => "tahoe",
+        24 => "sequoia",
+        23 => "sonoma",
+        22 => "ventura",
+        21 => "monterey",
+        20 => "big_sur",
+        else => return "",
     };
+    const prefix: []const u8 = if (arch == .aarch64) "arm64_" else "";
+    return std.fmt.bufPrint(buf, "{s}{s}", .{ prefix, name }) catch "";
+}
+
+/// Return the cask-variation tag for THIS machine (e.g. "arm64_tahoe"),
+/// or "" if it cannot be determined. Uses uname() — no subprocess.
+///
+/// Match policy: a variation must match this exact tag to override the
+/// top-level fields. Previously the resolver walked all known tags new-to-old
+/// and applied the first match, which downgraded current-macOS users when a
+/// cask had variations only for older OSes (e.g. raycast: top-level 1.104.18,
+/// arm64_monterey override 1.94.4 — a Tahoe user was incorrectly handed 1.94.4).
+pub fn currentMacOSVariationTag(buf: []u8) []const u8 {
+    const uname = std.posix.uname();
+    const release = std.mem.sliceTo(&uname.release, 0);
+    var it = std.mem.splitScalar(u8, release, '.');
+    const major_str = it.next() orelse return "";
+    const major = std.fmt.parseInt(u32, major_str, 10) catch return "";
+    return darwinReleaseToVariationTag(major, builtin.target.cpu.arch, buf);
+}
+
+/// If `obj.variations[variation_tag]` exists and is an object, return it.
+/// Otherwise null — caller falls back to top-level fields.
+fn variationOverrideObject(obj: std.json.ObjectMap, variation_tag: []const u8) ?std.json.ObjectMap {
+    if (variation_tag.len == 0) return null;
+    const var_val = obj.get("variations") orelse return null;
+    const variations = asObject(var_val) orelse return null;
+    const tag_val = variations.get(variation_tag) orelse return null;
+    return asObject(tag_val);
 }
 
 /// Fetch and resolve a cask from the per-cask API.
@@ -209,8 +267,18 @@ pub fn fetchAndResolveCask(allocator: Allocator, http_client: *HttpClient, token
     return try parseResolvedCask(allocator, json_bytes);
 }
 
-/// Parse a per-cask API JSON response into a ResolvedCask.
+/// Parse a per-cask API JSON response, applying the current machine's macOS
+/// variation. See parseResolvedCaskWithTag for tag semantics.
 pub fn parseResolvedCask(allocator: Allocator, json_bytes: []const u8) !ResolvedCask {
+    var tag_buf: [64]u8 = undefined;
+    const tag = currentMacOSVariationTag(&tag_buf);
+    return parseResolvedCaskWithTag(allocator, json_bytes, tag);
+}
+
+/// Parse a per-cask API JSON response into a ResolvedCask, applying the
+/// variation block for `variation_tag` iff it exists. Pass "" to skip
+/// variations entirely.
+pub fn parseResolvedCaskWithTag(allocator: Allocator, json_bytes: []const u8, variation_tag: []const u8) !ResolvedCask {
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{
         .allocate = .alloc_always,
     });
@@ -224,45 +292,24 @@ pub fn parseResolvedCask(allocator: Allocator, json_bytes: []const u8) !Resolved
     const result_token = try allocator.dupe(u8, jsonStr(obj, "token") orelse return error.MissingField);
     errdefer allocator.free(result_token);
 
-    // Start with top-level url/sha256/version, then override from variations.
-    var url = try allocator.dupe(u8, jsonStr(obj, "url") orelse "");
+    // Resolve url/sha256/version against the variation for this macOS, if any.
+    var url_src: []const u8 = jsonStr(obj, "url") orelse "";
+    var sha256_src: []const u8 = jsonStr(obj, "sha256") orelse "";
+    var version_src: []const u8 = jsonStr(obj, "version") orelse "";
+    if (variationOverrideObject(obj, variation_tag)) |tag_obj| {
+        if (jsonStr(tag_obj, "url")) |v| url_src = v;
+        if (jsonStr(tag_obj, "sha256")) |v| sha256_src = v;
+        if (jsonStr(tag_obj, "version")) |v| version_src = v;
+    }
+
+    const url = try allocator.dupe(u8, url_src);
     errdefer allocator.free(url);
 
-    var sha256 = try allocator.dupe(u8, jsonStr(obj, "sha256") orelse "");
+    const sha256 = try allocator.dupe(u8, sha256_src);
     errdefer allocator.free(sha256);
 
-    var version = try allocator.dupe(u8, jsonStr(obj, "version") orelse "");
+    const version = try allocator.dupe(u8, version_src);
     errdefer allocator.free(version);
-
-    // Check variations for platform-specific overrides.
-    // Allocate new values before freeing old ones to avoid double-free on OOM.
-    if (obj.get("variations")) |var_val| {
-        if (asObject(var_val)) |variations| {
-            const tags = platformVariationTags();
-            for (tags) |tag| {
-                if (variations.get(tag)) |tag_val| {
-                    if (asObject(tag_val)) |tag_obj| {
-                        if (jsonStr(tag_obj, "url")) |v_url| {
-                            const new_url = try allocator.dupe(u8, v_url);
-                            allocator.free(url);
-                            url = new_url;
-                        }
-                        if (jsonStr(tag_obj, "sha256")) |v_sha| {
-                            const new_sha = try allocator.dupe(u8, v_sha);
-                            allocator.free(sha256);
-                            sha256 = new_sha;
-                        }
-                        if (jsonStr(tag_obj, "version")) |v_ver| {
-                            const new_ver = try allocator.dupe(u8, v_ver);
-                            allocator.free(version);
-                            version = new_ver;
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-    }
 
     // Parse name (first element of name array).
     const result_name = blk: {
@@ -684,4 +731,151 @@ test "cleanArtifactPath strips HOMEBREW_PREFIX/Caskroom prefix" {
 
 test "cleanArtifactPath preserves plain paths" {
     try std.testing.expectEqualStrings("studio", cleanArtifactPath("studio"));
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2: variation-tag selection must match the user's actual macOS.
+// Previously the code iterated platformVariationTags() new-to-old and applied
+// the first match, which downgraded users on a recent macOS when a cask had
+// variations only for older OSes (e.g. raycast 1.99.3 -> 1.94.4).
+// ---------------------------------------------------------------------------
+
+test "parseSingleCaskJson without variations keeps top-level fields" {
+    const allocator = std.testing.allocator;
+    const json_bytes =
+        \\{
+        \\  "token": "raycast",
+        \\  "name": ["Raycast"],
+        \\  "url": "https://example.com/raycast-1.104.18.dmg",
+        \\  "version": "1.104.18",
+        \\  "sha256": "newhash"
+        \\}
+    ;
+    const info = try parseSingleCaskJson(allocator, json_bytes, "arm64_tahoe");
+    defer freeCask(allocator, info);
+    try std.testing.expectEqualStrings("1.104.18", info.version);
+    try std.testing.expectEqualStrings("https://example.com/raycast-1.104.18.dmg", info.url);
+    try std.testing.expectEqualStrings("newhash", info.sha256);
+}
+
+test "parseSingleCaskJson applies variation only when tag matches user OS" {
+    const allocator = std.testing.allocator;
+    // Top-level is the current Raycast; variations cap older macOS at 1.94.4.
+    // A Tahoe user must NOT pick up monterey's downgrade.
+    const json_bytes =
+        \\{
+        \\  "token": "raycast",
+        \\  "name": ["Raycast"],
+        \\  "url": "https://example.com/raycast-1.104.18.dmg",
+        \\  "version": "1.104.18",
+        \\  "sha256": "newhash",
+        \\  "variations": {
+        \\    "arm64_monterey": {
+        \\      "url": "https://example.com/raycast-1.94.4.dmg",
+        \\      "version": "1.94.4",
+        \\      "sha256": "oldhash"
+        \\    }
+        \\  }
+        \\}
+    ;
+    const tahoe = try parseSingleCaskJson(allocator, json_bytes, "arm64_tahoe");
+    defer freeCask(allocator, tahoe);
+    try std.testing.expectEqualStrings("1.104.18", tahoe.version);
+    try std.testing.expectEqualStrings("newhash", tahoe.sha256);
+}
+
+test "parseSingleCaskJson uses variation when tag matches" {
+    const allocator = std.testing.allocator;
+    const json_bytes =
+        \\{
+        \\  "token": "raycast",
+        \\  "name": ["Raycast"],
+        \\  "url": "https://example.com/raycast-1.104.18.dmg",
+        \\  "version": "1.104.18",
+        \\  "sha256": "newhash",
+        \\  "variations": {
+        \\    "arm64_monterey": {
+        \\      "url": "https://example.com/raycast-1.94.4.dmg",
+        \\      "version": "1.94.4",
+        \\      "sha256": "oldhash"
+        \\    }
+        \\  }
+        \\}
+    ;
+    const monterey = try parseSingleCaskJson(allocator, json_bytes, "arm64_monterey");
+    defer freeCask(allocator, monterey);
+    try std.testing.expectEqualStrings("1.94.4", monterey.version);
+    try std.testing.expectEqualStrings("oldhash", monterey.sha256);
+}
+
+test "parseResolvedCaskWithTag ignores non-matching variation" {
+    const allocator = std.testing.allocator;
+    const json_bytes =
+        \\{
+        \\  "token": "raycast",
+        \\  "name": ["Raycast"],
+        \\  "url": "https://example.com/raycast-1.104.18.dmg",
+        \\  "version": "1.104.18",
+        \\  "sha256": "newhash",
+        \\  "variations": {
+        \\    "arm64_monterey": {
+        \\      "url": "https://example.com/raycast-1.94.4.dmg",
+        \\      "version": "1.94.4",
+        \\      "sha256": "oldhash"
+        \\    }
+        \\  },
+        \\  "artifacts": [{"app": ["Raycast.app"]}]
+        \\}
+    ;
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "arm64_tahoe");
+    defer freeResolvedCask(allocator, resolved);
+    try std.testing.expectEqualStrings("1.104.18", resolved.version);
+}
+
+test "parseResolvedCaskWithTag picks matching variation" {
+    const allocator = std.testing.allocator;
+    const json_bytes =
+        \\{
+        \\  "token": "raycast",
+        \\  "name": ["Raycast"],
+        \\  "url": "https://example.com/raycast-1.104.18.dmg",
+        \\  "version": "1.104.18",
+        \\  "sha256": "newhash",
+        \\  "variations": {
+        \\    "arm64_monterey": {
+        \\      "url": "https://example.com/raycast-1.94.4.dmg",
+        \\      "version": "1.94.4",
+        \\      "sha256": "oldhash"
+        \\    }
+        \\  },
+        \\  "artifacts": [{"app": ["Raycast.app"]}]
+        \\}
+    ;
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "arm64_monterey");
+    defer freeResolvedCask(allocator, resolved);
+    try std.testing.expectEqualStrings("1.94.4", resolved.version);
+}
+
+test "currentMacOSVariationTag identifies Tahoe from Darwin 25" {
+    var buf: [64]u8 = undefined;
+    const tag = darwinReleaseToVariationTag(25, .aarch64, &buf);
+    try std.testing.expectEqualStrings("arm64_tahoe", tag);
+}
+
+test "currentMacOSVariationTag identifies Sequoia from Darwin 24" {
+    var buf: [64]u8 = undefined;
+    const tag = darwinReleaseToVariationTag(24, .aarch64, &buf);
+    try std.testing.expectEqualStrings("arm64_sequoia", tag);
+}
+
+test "currentMacOSVariationTag handles intel arch" {
+    var buf: [64]u8 = undefined;
+    const tag = darwinReleaseToVariationTag(23, .x86_64, &buf);
+    try std.testing.expectEqualStrings("sonoma", tag);
+}
+
+test "currentMacOSVariationTag returns empty for unknown release" {
+    var buf: [64]u8 = undefined;
+    const tag = darwinReleaseToVariationTag(99, .aarch64, &buf);
+    try std.testing.expectEqualStrings("", tag);
 }

--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -60,6 +60,13 @@ pub fn installCask(
     defer allocator.free(version_dir);
     try fs.cwd().makePath(version_dir);
 
+    // If we fail before linking, wipe the partial version_dir so it doesn't
+    // masquerade as an installed version — cellar.installedVersions reads the
+    // directory listing, so a stranded dir would falsely appear in `bru list`
+    // and `bru outdated` (Bug 4).
+    var commit = false;
+    errdefer if (!commit) fs.deleteTreeAbsolute(version_dir) catch {};
+
     // 5. Determine archive type and extract.
     const archive_kind = try detectArchiveKind(resolved.url, archive_path);
     out.print("Extracting {s}...\n", .{resolved.token});
@@ -84,16 +91,30 @@ pub fn installCask(
     //    binaries living inside an .app bundle (e.g. docker-desktop's
     //    Docker.app/Contents/Resources/bin/docker) resolve against
     //    /Applications, not the to-be-emptied version_dir.
+    //
+    //    During upgrade, stageApp force-replaces the existing /Applications
+    //    bundle (with a move-aside backup that's restored on failure). For a
+    //    fresh install, AppAlreadyInstalled is fatal — silently continuing
+    //    produced half-installed state where the caskroom and state file
+    //    claimed the new version but the user's /Applications still held the
+    //    old one (Bug 1).
+    const is_upgrade = upgrade_from != null;
     for (resolved.apps) |app| {
-        stageApp(allocator, version_dir, default_appdir, app) catch |stage_err| switch (stage_err) {
-            error.AppAlreadyInstalled => err_out.warn(
-                "{s} already exists in {s} — leaving it in place.",
-                .{ app.target, default_appdir },
-            ),
-            else => err_out.warn(
-                "Could not stage app \"{s}\": {s}",
-                .{ app.target, @errorName(stage_err) },
-            ),
+        stageApp(allocator, version_dir, default_appdir, app, is_upgrade) catch |stage_err| switch (stage_err) {
+            error.AppAlreadyInstalled => {
+                err_out.err(
+                    "{s} is already installed at {s}. Use `bru uninstall --cask {s}` first.",
+                    .{ app.target, default_appdir, resolved.token },
+                );
+                return error.AppAlreadyInstalled;
+            },
+            else => {
+                err_out.err(
+                    "Could not stage app \"{s}\": {s}",
+                    .{ app.target, @errorName(stage_err) },
+                );
+                return stage_err;
+            },
         };
     }
 
@@ -126,6 +147,11 @@ pub fn installCask(
     }
 
     try linker.link(resolved.token, version_dir);
+
+    // New version is staged, linked, and visible. The install is committed —
+    // any later failure (e.g. cleaning up the old version) is non-fatal and
+    // must not roll back the new install.
+    commit = true;
 
     // 8. For upgrades, remove the old caskroom version dir now that the new
     //    one is linked.
@@ -272,14 +298,17 @@ fn extractTar(allocator: Allocator, tar_path: []const u8, dest_dir: []const u8) 
 
 /// Stage a single app-bundle artifact:
 ///   1. Verify the extracted source bundle exists.
-///   2. Move it from `{version_dir}/{app.source}` to `{appdir}/{app.target}`
+///   2. If the destination already exists and `is_upgrade` is false, return
+///      `error.AppAlreadyInstalled` so the caller aborts the install — never
+///      silently proceed (that produced half-installed state, see Bug 1).
+///   3. If `is_upgrade` is true and the destination exists, move it aside to a
+///      sibling backup path before staging, restoring it if the move fails.
+///   4. Move new bundle from `{version_dir}/{app.source}` to `{appdir}/{app.target}`
 ///      using rename (same-volume) or `ditto`+`rm -rf` (cross-volume fallback).
-///   3. Leave a back-symlink at `{version_dir}/{app.target}` pointing to the
-///      installed bundle — this matches brew's default Caskroom layout and
-///      lets future correctness checks find the bundle via either path.
-/// Returns `error.AppAlreadyInstalled` if the destination already exists,
-/// so callers can warn-but-continue (brew does the same).
-fn stageApp(allocator: Allocator, version_dir: []const u8, appdir: []const u8, app: AppArtifact) !void {
+///   5. Leave a back-symlink at `{version_dir}/{app.target}` pointing to the
+///      installed bundle — matches brew's Caskroom layout.
+///   6. On full success, delete the moved-aside backup.
+fn stageApp(allocator: Allocator, version_dir: []const u8, appdir: []const u8, app: AppArtifact, is_upgrade: bool) !void {
     const source_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, app.source });
     defer allocator.free(source_path);
 
@@ -290,21 +319,33 @@ fn stageApp(allocator: Allocator, version_dir: []const u8, appdir: []const u8, a
         return error.AppNotFound;
     };
 
-    // If destination already exists, treat as already-installed (warn, don't
-    // overwrite — brew default).
-    if (fs.cwd().access(target_path, .{})) |_| {
-        return error.AppAlreadyInstalled;
-    } else |_| {}
+    const target_exists = blk: {
+        fs.cwd().access(target_path, .{}) catch break :blk false;
+        break :blk true;
+    };
 
-    // Same-volume rename first; if that fails (e.g. EXDEV across volumes),
-    // fall back to a recursive copy that preserves extended attributes
-    // (quarantine flags etc.) then delete the source.
-    if (fs.renameAbsolute(source_path, target_path)) |_| {
-        // ok
-    } else |rename_err| switch (rename_err) {
-        error.RenameAcrossMountPoints => try copyAppCrossVolume(allocator, source_path, target_path),
-        else => return rename_err,
+    if (target_exists and !is_upgrade) {
+        return error.AppAlreadyInstalled;
     }
+
+    // For upgrade-with-existing-target: move target aside to a sibling backup
+    // path. If staging fails we restore it; if it succeeds we delete it.
+    var backup_path_opt: ?[]u8 = null;
+    defer if (backup_path_opt) |p| allocator.free(p);
+
+    if (target_exists) {
+        const backup_path = try std.fmt.allocPrint(allocator, "{s}.bru-replacing.{d}", .{ target_path, std.time.nanoTimestamp() });
+        backup_path_opt = backup_path;
+        try fs.renameAbsolute(target_path, backup_path);
+    }
+
+    // Try to move the new bundle into place. On failure, restore the backup.
+    moveAppIntoPlace(allocator, source_path, target_path) catch |err| {
+        if (backup_path_opt) |p| {
+            fs.renameAbsolute(p, target_path) catch {};
+        }
+        return err;
+    };
 
     // Back-symlink {version_dir}/{target} -> {appdir}/{target}.
     const back_link = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, app.target });
@@ -314,6 +355,23 @@ fn stageApp(allocator: Allocator, version_dir: []const u8, appdir: []const u8, a
         else => return err,
     };
     try fs.symLinkAbsolute(target_path, back_link, .{});
+
+    // Success — drop the backup. Best-effort; a leftover .bru-replacing dir is
+    // harmless and is overwritten on the next upgrade attempt.
+    if (backup_path_opt) |p| {
+        fs.deleteTreeAbsolute(p) catch {};
+    }
+}
+
+/// Same-volume rename, falling back to `ditto`+`rm -rf` across volumes so
+/// extended attributes (quarantine flags, ACLs) survive.
+fn moveAppIntoPlace(allocator: Allocator, source_path: []const u8, target_path: []const u8) !void {
+    if (fs.renameAbsolute(source_path, target_path)) |_| {
+        return;
+    } else |rename_err| switch (rename_err) {
+        error.RenameAcrossMountPoints => try copyAppCrossVolume(allocator, source_path, target_path),
+        else => return rename_err,
+    }
 }
 
 /// Recursively copy an .app bundle across volumes using `ditto`, then remove
@@ -515,6 +573,118 @@ test "stageBinary returns error for missing binary" {
     const roots = [_][]const u8{version_dir};
     const result = stageBinary(allocator, &roots, bin_dir, binary);
     try std.testing.expectError(error.BinaryNotFound, result);
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: silent-skip on AppAlreadyInstalled
+// Upgrade must replace the existing .app; fresh install must abort cleanly.
+// ---------------------------------------------------------------------------
+
+test "stageApp returns AppAlreadyInstalled when fresh install and target exists" {
+    const allocator = std.testing.allocator;
+
+    var version_tmp = std.testing.tmpDir(.{});
+    defer version_tmp.cleanup();
+    var apps_tmp = std.testing.tmpDir(.{});
+    defer apps_tmp.cleanup();
+
+    // New version on disk in version_dir.
+    try version_tmp.dir.makePath("Foo.app");
+    const new_marker = try version_tmp.dir.createFile("Foo.app/marker", .{});
+    try new_marker.writeAll("new");
+    new_marker.close();
+
+    // Old version already at appdir — must not be replaced for fresh install.
+    try apps_tmp.dir.makePath("Foo.app");
+    const old_marker = try apps_tmp.dir.createFile("Foo.app/marker", .{});
+    try old_marker.writeAll("old");
+    old_marker.close();
+
+    var v_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try version_tmp.dir.realpath(".", &v_buf);
+    var a_buf: [fs.max_path_bytes]u8 = undefined;
+    const apps_dir = try apps_tmp.dir.realpath(".", &a_buf);
+
+    const app = AppArtifact{ .source = "Foo.app", .target = "Foo.app" };
+    const result = stageApp(allocator, version_dir, apps_dir, app, false);
+    try std.testing.expectError(error.AppAlreadyInstalled, result);
+
+    // Old content must survive.
+    const f = try apps_tmp.dir.openFile("Foo.app/marker", .{});
+    defer f.close();
+    var read: [3]u8 = undefined;
+    _ = try f.readAll(&read);
+    try std.testing.expectEqualStrings("old", &read);
+}
+
+test "stageApp replaces existing target when upgrading" {
+    const allocator = std.testing.allocator;
+
+    var version_tmp = std.testing.tmpDir(.{});
+    defer version_tmp.cleanup();
+    var apps_tmp = std.testing.tmpDir(.{});
+    defer apps_tmp.cleanup();
+
+    try version_tmp.dir.makePath("Foo.app");
+    const new_marker = try version_tmp.dir.createFile("Foo.app/marker", .{});
+    try new_marker.writeAll("new");
+    new_marker.close();
+
+    try apps_tmp.dir.makePath("Foo.app");
+    const old_marker = try apps_tmp.dir.createFile("Foo.app/marker", .{});
+    try old_marker.writeAll("old");
+    old_marker.close();
+
+    var v_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try version_tmp.dir.realpath(".", &v_buf);
+    var a_buf: [fs.max_path_bytes]u8 = undefined;
+    const apps_dir = try apps_tmp.dir.realpath(".", &a_buf);
+
+    const app = AppArtifact{ .source = "Foo.app", .target = "Foo.app" };
+    try stageApp(allocator, version_dir, apps_dir, app, true);
+
+    // /Applications/Foo.app/marker should now contain "new".
+    const f = try apps_tmp.dir.openFile("Foo.app/marker", .{});
+    defer f.close();
+    var read: [3]u8 = undefined;
+    _ = try f.readAll(&read);
+    try std.testing.expectEqualStrings("new", &read);
+
+    // No leftover .bru-replacing-* directories.
+    var apps_iter = try apps_tmp.dir.openDir(".", .{ .iterate = true });
+    defer apps_iter.close();
+    var walker = apps_iter.iterate();
+    while (try walker.next()) |entry| {
+        try std.testing.expect(std.mem.indexOf(u8, entry.name, ".bru-replacing") == null);
+    }
+}
+
+test "stageApp upgrade with no existing target installs cleanly" {
+    const allocator = std.testing.allocator;
+
+    var version_tmp = std.testing.tmpDir(.{});
+    defer version_tmp.cleanup();
+    var apps_tmp = std.testing.tmpDir(.{});
+    defer apps_tmp.cleanup();
+
+    try version_tmp.dir.makePath("Bar.app");
+    const f = try version_tmp.dir.createFile("Bar.app/marker", .{});
+    try f.writeAll("v2");
+    f.close();
+
+    var v_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try version_tmp.dir.realpath(".", &v_buf);
+    var a_buf: [fs.max_path_bytes]u8 = undefined;
+    const apps_dir = try apps_tmp.dir.realpath(".", &a_buf);
+
+    const app = AppArtifact{ .source = "Bar.app", .target = "Bar.app" };
+    try stageApp(allocator, version_dir, apps_dir, app, true);
+
+    const f2 = try apps_tmp.dir.openFile("Bar.app/marker", .{});
+    defer f2.close();
+    var read: [2]u8 = undefined;
+    _ = try f2.readAll(&read);
+    try std.testing.expectEqualStrings("v2", &read);
 }
 
 test "stageBinary falls back to second source root" {

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -408,7 +408,10 @@ fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: O
     }
 
     // Run the cask install pipeline.
-    try cask_install.installCask(allocator, config, &http_client, resolved, null);
+    cask_install.installCask(allocator, config, &http_client, resolved, null) catch |install_err| {
+        err_out.err("Failed to install cask \"{s}\" ({s}): {s}", .{ name, resolved.url, @errorName(install_err) });
+        return install_err;
+    };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -759,7 +759,7 @@ fn runCaskUpgrade(
         }
 
         cask_install.installCask(allocator, config, &http_client, resolved, item.installed_version) catch |install_err| {
-            err_out.err("Failed to upgrade cask \"{s}\": {s}", .{ item.token, @errorName(install_err) });
+            err_out.err("Failed to upgrade cask \"{s}\" ({s}): {s}", .{ item.token, resolved.url, @errorName(install_err) });
             continue;
         };
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -140,8 +140,25 @@ fn attemptFetch(
     try file_writer.interface.flush();
 
     if (result.status.class() != .success) {
+        // Emit context to stderr before returning the bare error so users can
+        // see WHY the download failed (status code + URL). Bare HttpError
+        // alone is unactionable (Bug 3).
+        var msg_buf: [1024]u8 = undefined;
+        const msg = formatHttpFailure(&msg_buf, @intFromEnum(result.status), url);
+        std.debug.print("{s}\n", .{msg});
         return error.HttpError;
     }
+}
+
+/// Format an HTTP failure into `buf` as "HTTP {code} from {url}". If the
+/// buffer is too small, the message is truncated but always starts with
+/// "HTTP {code}" so the most important info survives.
+fn formatHttpFailure(buf: []u8, status_code: u16, url: []const u8) []const u8 {
+    return std.fmt.bufPrint(buf, "HTTP {d} from {s}", .{ status_code, url }) catch blk: {
+        // bufPrint failed because the URL doesn't fit. Truncate by writing
+        // just the status code, which always fits in a sensible buffer.
+        break :blk std.fmt.bufPrint(buf, "HTTP {d}", .{status_code}) catch buf[0..0];
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +171,22 @@ test "isTransient classifies retriable errors" {
     try std.testing.expect(isTransient(error.ConnectionResetByPeer));
     try std.testing.expect(!isTransient(error.HttpError));
     try std.testing.expect(!isTransient(error.OutOfMemory));
+}
+
+test "formatHttpFailure includes status code and URL" {
+    var buf: [256]u8 = undefined;
+    const msg = formatHttpFailure(&buf, 404, "https://example.com/foo.dmg");
+    try std.testing.expectEqualStrings(
+        "HTTP 404 from https://example.com/foo.dmg",
+        msg,
+    );
+}
+
+test "formatHttpFailure truncates long URLs gracefully" {
+    var buf: [40]u8 = undefined;
+    const msg = formatHttpFailure(&buf, 500, "https://example.com/path");
+    // Buffer can't hold the whole message; we still want a sane prefix.
+    try std.testing.expect(std.mem.startsWith(u8, msg, "HTTP 500"));
 }
 
 test "HttpClient fetch downloads a file" {


### PR DESCRIPTION
## Summary
- `bru upgrade` no longer silently downgrades casks on recent macOS when an older OS has a variation override (e.g., Raycast 1.99.3 → 1.94.4).
- Cask upgrades now actually replace the `.app` in `/Applications` instead of warning and reporting fake success.
- Failed installs clean up the partial caskroom dir instead of leaving it stranded.
- Download/HTTP errors include the status code and URL so users can debug.

## Test plan
- [x] 318/318 unit tests pass (14 new for variation matching, app replacement, tag detection, and HTTP error formatting)
- [x] End-to-end upgrade verified on `/Applications/Rectangle.app`: `.app` replaced (mtime confirms fresh DMG extract), old caskroom rotated out, state recorded, no `.bru-replacing.*` leftovers
- [x] Release build clean