### PR TITLE
feat: support pkg casks, gated on whether bru can uninstall them

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Anything not implemented natively falls back to the real `brew` binary.
 | **Dependencies** | ~30 Rust crates, SQLite, Tokio | Zero — Zig stdlib only |
 | **Binary size** | 7.9 MB | Single static binary, significantly smaller |
 | **Migration** | Required (`zb migrate`) | Not needed — works on existing Homebrew installation |
-| **Casks** | Not supported | `.app` casks (binary-and-app artifacts) work; brew falls back for `.pkg`/font casks |
+| **Casks** | Not supported | `.app`, binary, and `.pkg` casks work — `.pkg` installs via `installer` and uninstalls via `pkgutil`/`delete`/`trash`/`rmdir`. A pkg cask whose `uninstall` needs steps bru lacks (`launchctl`, `quit`, `script`, `kext`) defers to brew rather than install something it can't cleanly remove |
 | **Correctness** | Skips patching ffmpeg's `libav*.pc` pkg-config files — `@@HOMEBREW_PREFIX@@` placeholders leak through (see Benchmark below) | Full pkg-config patching alongside Mach-O relocation |
 
 ### vs nanobrew

--- a/src/cask.zig
+++ b/src/cask.zig
@@ -192,6 +192,30 @@ pub const AppArtifact = struct {
     target: []const u8, // destination basename in /Applications, e.g., "Rectangle.app"
 };
 
+/// A macOS installer package. Nothing to extract — it is handed to
+/// `/usr/sbin/installer -target /`, which writes to absolute paths it declares.
+pub const PkgArtifact = struct {
+    source: []const u8, // path to the .pkg relative to the staged version dir
+    allow_untrusted: bool, // `pkg "x.pkg", allow_untrusted: true`
+};
+
+/// A cask's `uninstall` stanza, split into directives bru can carry out and
+/// those it cannot. A pkg cask writes outside the Caskroom, so this is the
+/// only record of what to remove; `unsupported` drives the install-time gate.
+pub const UninstallPlan = struct {
+    pkgutil: [][]const u8, // receipts to forget, and whose payload to delete
+    delete: [][]const u8, // paths to remove outright
+    rmdir: [][]const u8, // dirs to remove only if they end up empty
+    trash: [][]const u8, // paths to move to the user's Trash
+    /// Directives bru does not implement (launchctl, quit, script, ...), deduped.
+    unsupported: [][]const u8,
+
+    pub fn isEmpty(self: UninstallPlan) bool {
+        return self.pkgutil.len == 0 and self.delete.len == 0 and
+            self.rmdir.len == 0 and self.trash.len == 0;
+    }
+};
+
 /// Resolved metadata for installing a single cask, fetched from per-cask API.
 pub const ResolvedCask = struct {
     token: []const u8,
@@ -201,6 +225,8 @@ pub const ResolvedCask = struct {
     name: []const u8,
     binaries: []BinaryArtifact,
     apps: []AppArtifact,
+    pkgs: []PkgArtifact,
+    uninstall: UninstallPlan,
 };
 
 /// Map a Darwin kernel major version and CPU arch to the Homebrew cask
@@ -339,6 +365,24 @@ pub fn parseResolvedCaskWithTag(allocator: Allocator, json_bytes: []const u8, va
 
     // Parse app-bundle artifacts (e.g. `app "Rectangle.app"`).
     const apps = try parseAppArtifacts(allocator, obj);
+    errdefer {
+        for (apps) |a| {
+            allocator.free(a.source);
+            allocator.free(a.target);
+        }
+        allocator.free(apps);
+    }
+
+    // Parse pkg artifacts (e.g. `pkg "session-manager-plugin.pkg"`).
+    const pkgs = try parsePkgArtifacts(allocator, obj);
+    errdefer {
+        for (pkgs) |p| allocator.free(p.source);
+        allocator.free(pkgs);
+    }
+
+    // Parse the `uninstall` stanza so an install can be undone later, and so
+    // the caller can tell whether bru is able to undo it at all.
+    const uninstall = try parseUninstallPlan(allocator, obj);
 
     return ResolvedCask{
         .token = result_token,
@@ -348,6 +392,8 @@ pub fn parseResolvedCaskWithTag(allocator: Allocator, json_bytes: []const u8, va
         .name = result_name,
         .binaries = binaries,
         .apps = apps,
+        .pkgs = pkgs,
+        .uninstall = uninstall,
     };
 }
 
@@ -477,6 +523,180 @@ fn parseAppArtifacts(allocator: Allocator, obj: std.json.ObjectMap) ![]AppArtifa
     return try result.toOwnedSlice(allocator);
 }
 
+/// A cask's `artifacts` entries, empty when the key is absent or malformed.
+fn artifactsArray(obj: std.json.ObjectMap) []const std.json.Value {
+    const val = obj.get("artifacts") orelse return &.{};
+    return switch (val) {
+        .array => |a| a.items,
+        else => &.{},
+    };
+}
+
+/// Parse pkg artifacts: {"pkg": ["Foo.pkg"]} or ["Foo.pkg", {"allow_untrusted": true}].
+// TODO: `choices` (installer choice overrides) is ignored; those casks install
+// with the package's defaults.
+fn parsePkgArtifacts(allocator: Allocator, obj: std.json.ObjectMap) ![]PkgArtifact {
+    var result = std.ArrayList(PkgArtifact){};
+    errdefer {
+        for (result.items) |p| allocator.free(p.source);
+        result.deinit(allocator);
+    }
+
+    for (artifactsArray(obj)) |artifact_val| {
+        const artifact_obj = switch (artifact_val) {
+            .object => |o| o,
+            else => continue,
+        };
+
+        const pkg_val = artifact_obj.get("pkg") orelse continue;
+        const pkg_arr = switch (pkg_val) {
+            .array => |a| a,
+            else => continue,
+        };
+        if (pkg_arr.items.len == 0) continue;
+
+        const source_raw = switch (pkg_arr.items[0]) {
+            .string => |s| s,
+            else => continue,
+        };
+
+        var allow_untrusted = false;
+        if (pkg_arr.items.len > 1) {
+            if (asObject(pkg_arr.items[1])) |opts| {
+                allow_untrusted = jsonBool(opts, "allow_untrusted") orelse false;
+            }
+        }
+
+        const source = try allocator.dupe(u8, cleanArtifactPath(source_raw));
+        errdefer allocator.free(source);
+
+        try result.append(allocator, .{ .source = source, .allow_untrusted = allow_untrusted });
+    }
+
+    return try result.toOwnedSlice(allocator);
+}
+
+/// Parse a cask's `uninstall` stanza; each directive value is a string or an
+/// array of them. Unimplemented directives are named in `unsupported` rather
+/// than dropped, so the caller can say why it is deferring to brew.
+fn parseUninstallPlan(allocator: Allocator, obj: std.json.ObjectMap) !UninstallPlan {
+    var pkgutil = std.ArrayList([]const u8){};
+    var delete = std.ArrayList([]const u8){};
+    var rmdir = std.ArrayList([]const u8){};
+    var trash = std.ArrayList([]const u8){};
+    var unsupported = std.ArrayList([]const u8){};
+
+    errdefer {
+        for ([_]*std.ArrayList([]const u8){ &pkgutil, &delete, &rmdir, &trash, &unsupported }) |list| {
+            for (list.items) |s| allocator.free(s);
+            list.deinit(allocator);
+        }
+    }
+
+    for (artifactsArray(obj)) |artifact_val| {
+        const artifact_obj = switch (artifact_val) {
+            .object => |o| o,
+            else => continue,
+        };
+
+        const uninstall_val = artifact_obj.get("uninstall") orelse continue;
+        const uninstall_arr = switch (uninstall_val) {
+            .array => |a| a,
+            else => continue,
+        };
+
+        for (uninstall_arr.items) |directive_val| {
+            const directive = asObject(directive_val) orelse continue;
+            var it = directive.iterator();
+            while (it.next()) |kv| {
+                const key = kv.key_ptr.*;
+                const target: ?*std.ArrayList([]const u8) =
+                    if (mem.eql(u8, key, "pkgutil")) &pkgutil
+                    else if (mem.eql(u8, key, "delete")) &delete
+                    else if (mem.eql(u8, key, "rmdir")) &rmdir
+                    else if (mem.eql(u8, key, "trash")) &trash
+                    else null;
+
+                const list = target orelse {
+                    try appendUnique(allocator, &unsupported, key);
+                    continue;
+                };
+
+                // A pkgutil value may be a Ruby Regexp; guessing which
+                // receipts it covers could forget another package's.
+                const literal_only = mem.eql(u8, key, "pkgutil");
+                if (!try appendStringValues(allocator, list, kv.value_ptr.*, literal_only)) {
+                    try appendUnique(allocator, &unsupported, key);
+                }
+            }
+        }
+    }
+
+    return UninstallPlan{
+        .pkgutil = try pkgutil.toOwnedSlice(allocator),
+        .delete = try delete.toOwnedSlice(allocator),
+        .rmdir = try rmdir.toOwnedSlice(allocator),
+        .trash = try trash.toOwnedSlice(allocator),
+        .unsupported = try unsupported.toOwnedSlice(allocator),
+    };
+}
+
+/// Append a directive's string or string-array value to `list`. False when a
+/// value was skipped, telling the caller to mark the directive unsupported.
+fn appendStringValues(
+    allocator: Allocator,
+    list: *std.ArrayList([]const u8),
+    value: std.json.Value,
+    literal_only: bool,
+) !bool {
+    switch (value) {
+        .string => |s| {
+            if (literal_only and !pkgutilIdIsLiteral(s)) return false;
+            try list.append(allocator, try allocator.dupe(u8, s));
+            return true;
+        },
+        .array => |items| {
+            var complete = true;
+            for (items.items) |item| {
+                const s = switch (item) {
+                    .string => |v| v,
+                    else => {
+                        complete = false;
+                        continue;
+                    },
+                };
+                if (literal_only and !pkgutilIdIsLiteral(s)) {
+                    complete = false;
+                    continue;
+                }
+                try list.append(allocator, try allocator.dupe(u8, s));
+            }
+            return complete;
+        },
+        else => return false,
+    }
+}
+
+/// Append `value` to `list` unless it is already present.
+fn appendUnique(allocator: Allocator, list: *std.ArrayList([]const u8), value: []const u8) !void {
+    for (list.items) |existing| {
+        if (mem.eql(u8, existing, value)) return;
+    }
+    try list.append(allocator, try allocator.dupe(u8, value));
+}
+
+/// True when a pkgutil ID is a plain package identifier (reverse-DNS-ish)
+/// rather than a regex. A mis-expanded pattern would forget other packages.
+fn pkgutilIdIsLiteral(id: []const u8) bool {
+    if (id.len == 0) return false;
+    for (id) |c| {
+        const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or c == '.' or c == '-' or c == '_' or c == '+';
+        if (!ok) return false;
+    }
+    return true;
+}
+
 /// Strip known prefixes from cask binary artifact paths.
 /// Removes "$HOMEBREW_PREFIX/Caskroom/{token}/{version}/" and "$APPDIR/" prefixes.
 fn cleanArtifactPath(path: []const u8) []const u8 {
@@ -505,6 +725,24 @@ fn asObject(val: std.json.Value) ?std.json.ObjectMap {
     };
 }
 
+/// Whether bru can install a cask, and if not, why.
+pub const Installability = enum {
+    ok,
+    /// No artifact kind bru handles (font, installer, manpage, ...).
+    no_artifacts,
+    /// Installs as root but declares uninstall steps bru cannot perform, so
+    /// bru could not take it back out again.
+    unremovable,
+};
+
+/// Single source of truth for "should bru handle this cask itself?" — install
+/// and upgrade must agree, or upgrade becomes a way around the install gate.
+pub fn installability(c: ResolvedCask) Installability {
+    if (c.binaries.len == 0 and c.apps.len == 0 and c.pkgs.len == 0) return .no_artifacts;
+    if (c.pkgs.len > 0 and c.uninstall.unsupported.len > 0) return .unremovable;
+    return .ok;
+}
+
 /// Free a ResolvedCask and all its owned memory.
 pub fn freeResolvedCask(allocator: Allocator, c: ResolvedCask) void {
     allocator.free(c.token);
@@ -522,6 +760,17 @@ pub fn freeResolvedCask(allocator: Allocator, c: ResolvedCask) void {
         allocator.free(a.target);
     }
     allocator.free(c.apps);
+    for (c.pkgs) |p| allocator.free(p.source);
+    allocator.free(c.pkgs);
+    freeUninstallPlan(allocator, c.uninstall);
+}
+
+/// Free an UninstallPlan and all its owned strings.
+pub fn freeUninstallPlan(allocator: Allocator, plan: UninstallPlan) void {
+    for ([_][][]const u8{ plan.pkgutil, plan.delete, plan.rmdir, plan.trash, plan.unsupported }) |list| {
+        for (list) |s| allocator.free(s);
+        allocator.free(list);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -715,6 +964,211 @@ test "parseResolvedCask app artifact with target rename" {
     try std.testing.expectEqualStrings("Dest.app", resolved.apps[0].target);
 }
 
+// ---------------------------------------------------------------------------
+// pkg artifacts — shapes below are real payloads from the cask API.
+// ---------------------------------------------------------------------------
+
+test "parseResolvedCask parses pkg artifact and pkgutil uninstall id" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "session-manager-plugin",
+        \\  "version": "1.2.835.0",
+        \\  "url": "https://example.com/session-manager-plugin.pkg",
+        \\  "sha256": "abc123",
+        \\  "name": ["Session Manager Plugin for the AWS CLI"],
+        \\  "artifacts": [
+        \\    {"uninstall": [{"pkgutil": "session-manager-plugin"}]},
+        \\    {"pkg": ["session-manager-plugin.pkg"]},
+        \\    {"binary": ["/usr/local/sessionmanagerplugin/bin/session-manager-plugin"], "target": "$HOMEBREW_PREFIX/bin/session-manager-plugin"},
+        \\    {"zap": [{"trash": "/Library/LaunchDaemons/SessionManagerPlugin.plist"}]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.pkgs.len);
+    try std.testing.expectEqualStrings("session-manager-plugin.pkg", resolved.pkgs[0].source);
+    try std.testing.expectEqual(false, resolved.pkgs[0].allow_untrusted);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.pkgutil.len);
+    try std.testing.expectEqualStrings("session-manager-plugin", resolved.uninstall.pkgutil[0]);
+
+    // pkgutil-only: bru can fully undo this install, so no gate.
+    try std.testing.expectEqual(@as(usize, 0), resolved.uninstall.unsupported.len);
+
+    // Absolute: it lives where the pkg put it, not in the Caskroom.
+    try std.testing.expectEqual(@as(usize, 1), resolved.binaries.len);
+    try std.testing.expectEqualStrings(
+        "/usr/local/sessionmanagerplugin/bin/session-manager-plugin",
+        resolved.binaries[0].source,
+    );
+    try std.testing.expectEqualStrings("session-manager-plugin", resolved.binaries[0].target);
+
+    // No app bundle, and the zap stanza must not be mistaken for one.
+    try std.testing.expectEqual(@as(usize, 0), resolved.apps.len);
+}
+
+test "parseResolvedCask parses pkg allow_untrusted and array pkgutil ids" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "example",
+        \\  "version": "1.0",
+        \\  "url": "https://example.com/x.dmg",
+        \\  "sha256": "abc",
+        \\  "name": ["Example"],
+        \\  "artifacts": [
+        \\    {"pkg": ["Installer.pkg", {"allow_untrusted": true}]},
+        \\    {"uninstall": [{"pkgutil": ["com.example.one", "com.example.two"]}]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.pkgs.len);
+    try std.testing.expectEqualStrings("Installer.pkg", resolved.pkgs[0].source);
+    try std.testing.expectEqual(true, resolved.pkgs[0].allow_untrusted);
+
+    try std.testing.expectEqual(@as(usize, 2), resolved.uninstall.pkgutil.len);
+    try std.testing.expectEqualStrings("com.example.one", resolved.uninstall.pkgutil[0]);
+    try std.testing.expectEqualStrings("com.example.two", resolved.uninstall.pkgutil[1]);
+}
+
+test "parseUninstallPlan rejects regex pkgutil patterns as unsupported" {
+    const allocator = std.testing.allocator;
+
+    // brew allows a Regexp for pkgutil:. Forgetting receipts by a pattern bru
+    // cannot evaluate risks clobbering unrelated packages, so these are dropped.
+    const json_bytes =
+        \\{
+        \\  "token": "example",
+        \\  "version": "1.0",
+        \\  "url": "https://example.com/x.pkg",
+        \\  "sha256": "abc",
+        \\  "name": ["Example"],
+        \\  "artifacts": [
+        \\    {"uninstall": [{"pkgutil": ["com.example.plain", "com\\.example\\..*", "com.example.*"]}]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.pkgutil.len);
+    try std.testing.expectEqualStrings("com.example.plain", resolved.uninstall.pkgutil[0]);
+
+    // Dropping a pattern makes the uninstall incomplete, so the gate must fire.
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.unsupported.len);
+    try std.testing.expectEqualStrings("pkgutil", resolved.uninstall.unsupported[0]);
+}
+
+test "parseResolvedCask leaves pkg fields empty for a plain app cask" {
+    const allocator = std.testing.allocator;
+
+    const json_bytes =
+        \\{
+        \\  "token": "chrome",
+        \\  "version": "1.0",
+        \\  "url": "https://example.com/x.dmg",
+        \\  "sha256": "abc",
+        \\  "name": ["Chrome"],
+        \\  "artifacts": [{"app": ["Google Chrome.app"]}]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 0), resolved.pkgs.len);
+    try std.testing.expect(resolved.uninstall.isEmpty());
+    try std.testing.expectEqual(@as(usize, 0), resolved.uninstall.unsupported.len);
+}
+
+test "parseUninstallPlan collects delete, rmdir, and trash paths" {
+    const allocator = std.testing.allocator;
+
+    // adguard's shape: delete as an array, rmdir as a bare string.
+    const json_bytes =
+        \\{
+        \\  "token": "example",
+        \\  "version": "1.0",
+        \\  "url": "https://example.com/x.pkg",
+        \\  "sha256": "abc",
+        \\  "name": ["Example"],
+        \\  "artifacts": [
+        \\    {"pkg": ["Example.pkg"]},
+        \\    {"uninstall": [{
+        \\      "pkgutil": "com.example.app",
+        \\      "delete": ["/Library/Application Support/Example", "~/Library/Logs/Example"],
+        \\      "rmdir": "/Library/Application Support/Example Software",
+        \\      "trash": "/Library/Audio/Plug-Ins/HAL/Example.driver"
+        \\    }]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 2), resolved.uninstall.delete.len);
+    try std.testing.expectEqualStrings("/Library/Application Support/Example", resolved.uninstall.delete[0]);
+    // Tilde paths survive parsing verbatim; expansion happens at uninstall.
+    try std.testing.expectEqualStrings("~/Library/Logs/Example", resolved.uninstall.delete[1]);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.rmdir.len);
+    try std.testing.expectEqualStrings("/Library/Application Support/Example Software", resolved.uninstall.rmdir[0]);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.trash.len);
+    try std.testing.expectEqual(@as(usize, 0), resolved.uninstall.unsupported.len);
+}
+
+test "parseUninstallPlan reports directives bru cannot carry out" {
+    const allocator = std.testing.allocator;
+
+    // 60% of pkg casks look like this.
+    const json_bytes =
+        \\{
+        \\  "token": "example",
+        \\  "version": "1.0",
+        \\  "url": "https://example.com/x.pkg",
+        \\  "sha256": "abc",
+        \\  "name": ["Example"],
+        \\  "artifacts": [
+        \\    {"pkg": ["Example.pkg"]},
+        \\    {"uninstall": [
+        \\      {"launchctl": "com.example.daemon", "quit": "com.example.app"},
+        \\      {"pkgutil": "com.example.app"},
+        \\      {"launchctl": "com.example.other"}
+        \\    ]}
+        \\  ]
+        \\}
+    ;
+
+    const resolved = try parseResolvedCaskWithTag(allocator, json_bytes, "");
+    defer freeResolvedCask(allocator, resolved);
+
+    try std.testing.expectEqual(@as(usize, 1), resolved.uninstall.pkgutil.len);
+
+    // Unsupported ones are named once each for the gate message.
+    try std.testing.expectEqual(@as(usize, 2), resolved.uninstall.unsupported.len);
+    var saw_launchctl = false;
+    var saw_quit = false;
+    for (resolved.uninstall.unsupported) |d| {
+        if (mem.eql(u8, d, "launchctl")) saw_launchctl = true;
+        if (mem.eql(u8, d, "quit")) saw_quit = true;
+    }
+    try std.testing.expect(saw_launchctl);
+    try std.testing.expect(saw_quit);
+}
+
 test "cleanArtifactPath strips APPDIR prefix" {
     try std.testing.expectEqualStrings(
         "Visual Studio Code.app/Contents/Resources/app/bin/code",
@@ -878,4 +1332,38 @@ test "currentMacOSVariationTag returns empty for unknown release" {
     var buf: [64]u8 = undefined;
     const tag = darwinReleaseToVariationTag(99, .aarch64, &buf);
     try std.testing.expectEqualStrings("", tag);
+}
+
+test "installability gates pkg casks bru could not uninstall" {
+    const empty_plan = UninstallPlan{ .pkgutil = &.{}, .delete = &.{}, .rmdir = &.{}, .trash = &.{}, .unsupported = &.{} };
+    var base = ResolvedCask{
+        .token = "x",
+        .version = "1",
+        .url = "",
+        .sha256 = "",
+        .name = "X",
+        .binaries = &.{},
+        .apps = &.{},
+        .pkgs = &.{},
+        .uninstall = empty_plan,
+    };
+    try std.testing.expectEqual(Installability.no_artifacts, installability(base));
+
+    var pkgs = [_]PkgArtifact{.{ .source = "a.pkg", .allow_untrusted = false }};
+    base.pkgs = &pkgs;
+    try std.testing.expectEqual(Installability.ok, installability(base));
+
+    // A pkg cask needing launchctl must be refused by BOTH install and
+    // upgrade — upgrade is otherwise a way around the gate, since brew fills
+    // the same Caskroom that `bru upgrade` scans.
+    var unsupported = [_][]const u8{"launchctl"};
+    base.uninstall.unsupported = &unsupported;
+    try std.testing.expectEqual(Installability.unremovable, installability(base));
+
+    // The same stanza on an app cask is not gated: bru never installs it as
+    // root, so there is nothing unremovable to guard against.
+    base.pkgs = &.{};
+    var apps = [_]AppArtifact{.{ .source = "A.app", .target = "A.app" }};
+    base.apps = &apps;
+    try std.testing.expectEqual(Installability.ok, installability(base));
 }

--- a/src/cask.zig
+++ b/src/cask.zig
@@ -632,11 +632,22 @@ fn parseUninstallPlan(allocator: Allocator, obj: std.json.ObjectMap) !UninstallP
         }
     }
 
+    // toOwnedSlice empties the list on success, so a later failure would put
+    // the earlier ones out of the errdefer's reach.
+    const pkgutil_owned = try pkgutil.toOwnedSlice(allocator);
+    errdefer freeStrings(allocator, pkgutil_owned);
+    const delete_owned = try delete.toOwnedSlice(allocator);
+    errdefer freeStrings(allocator, delete_owned);
+    const rmdir_owned = try rmdir.toOwnedSlice(allocator);
+    errdefer freeStrings(allocator, rmdir_owned);
+    const trash_owned = try trash.toOwnedSlice(allocator);
+    errdefer freeStrings(allocator, trash_owned);
+
     return UninstallPlan{
-        .pkgutil = try pkgutil.toOwnedSlice(allocator),
-        .delete = try delete.toOwnedSlice(allocator),
-        .rmdir = try rmdir.toOwnedSlice(allocator),
-        .trash = try trash.toOwnedSlice(allocator),
+        .pkgutil = pkgutil_owned,
+        .delete = delete_owned,
+        .rmdir = rmdir_owned,
+        .trash = trash_owned,
         .unsupported = try unsupported.toOwnedSlice(allocator),
     };
 }
@@ -739,7 +750,7 @@ pub const Installability = enum {
 /// and upgrade must agree, or upgrade becomes a way around the install gate.
 pub fn installability(c: ResolvedCask) Installability {
     if (c.binaries.len == 0 and c.apps.len == 0 and c.pkgs.len == 0) return .no_artifacts;
-    if (c.pkgs.len > 0 and c.uninstall.unsupported.len > 0) return .unremovable;
+    if (c.pkgs.len > 0 and (c.uninstall.unsupported.len > 0 or c.uninstall.isEmpty())) return .unremovable;
     return .ok;
 }
 
@@ -763,6 +774,11 @@ pub fn freeResolvedCask(allocator: Allocator, c: ResolvedCask) void {
     for (c.pkgs) |p| allocator.free(p.source);
     allocator.free(c.pkgs);
     freeUninstallPlan(allocator, c.uninstall);
+}
+
+fn freeStrings(allocator: Allocator, list: []const []const u8) void {
+    for (list) |s| allocator.free(s);
+    allocator.free(list);
 }
 
 /// Free an UninstallPlan and all its owned strings.
@@ -1349,8 +1365,14 @@ test "installability gates pkg casks bru could not uninstall" {
     };
     try std.testing.expectEqual(Installability.no_artifacts, installability(base));
 
+    // A pkg cask with no uninstall stanza is equally unremovable: nothing gets
+    // recorded, so `bru uninstall` would orphan the whole root payload.
     var pkgs = [_]PkgArtifact{.{ .source = "a.pkg", .allow_untrusted = false }};
     base.pkgs = &pkgs;
+    try std.testing.expectEqual(Installability.unremovable, installability(base));
+
+    var ids = [_][]const u8{"com.example.a"};
+    base.uninstall.pkgutil = &ids;
     try std.testing.expectEqual(Installability.ok, installability(base));
 
     // A pkg cask needing launchctl must be refused by BOTH install and

--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -11,6 +11,10 @@ const cask = @import("cask.zig");
 const ResolvedCask = cask.ResolvedCask;
 const BinaryArtifact = cask.BinaryArtifact;
 const AppArtifact = cask.AppArtifact;
+const UninstallPlan = cask.UninstallPlan;
+const json_helpers = @import("json_helpers.zig");
+const writeJsonStr = json_helpers.writeJsonStr;
+const clonefile = @import("clonefile.zig");
 
 /// Default destination for app bundles. Matches Homebrew's default `appdir`.
 const default_appdir: []const u8 = "/Applications";
@@ -30,6 +34,11 @@ pub fn installCask(
 ) !void {
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
+
+    // Refuse rather than trust callers: installing a root-owned payload bru
+    // cannot record an undo for is the one outcome there is no recovery from.
+    // cmd/install.zig catches this earlier to print a friendlier deferral.
+    if (cask.installability(resolved) == .unremovable) return error.CaskNotRemovable;
 
     // 1. Check if already installed (skip for upgrades).
     if (upgrade_from == null) {
@@ -75,15 +84,62 @@ pub fn installCask(
         .dmg => try extractDmg(allocator, archive_path, version_dir),
         .zip => try extractZip(allocator, archive_path, version_dir),
         .tar => try extractTar(allocator, archive_path, version_dir),
-        .pkg => {
-            err_out.warn("PKG archives cannot be extracted for binary-only install.", .{});
-            err_out.print("Use: brew install --cask {s}\n", .{resolved.token});
-            return error.UnsupportedArchiveType;
-        },
+        // NOTE: a bare .pkg is not an archive; stage it under the name the
+        // cask's `pkg` artifact refers to.
+        .pkg => try stagePkgFile(allocator, resolved, archive_path, version_dir),
         .unknown => {
             err_out.err("Unsupported archive format for {s}", .{resolved.token});
             return error.UnsupportedArchiveType;
         },
+    }
+
+    // 5b. Record the undo plan before anything leaves the Caskroom — it must
+    //     exist the moment `installer` starts touching the system.
+    //
+    //     WARNING: only record a plan bru can run in full — `delete:` without
+    //     the `launchctl:` that precedes it strips a loaded daemon's files
+    //     while launchd still references them. The gate above guarantees that
+    //     for pkg casks; app casks are left with their prior behaviour rather
+    //     than gaining half a teardown from this change.
+    if (resolved.pkgs.len > 0 and !resolved.uninstall.isEmpty()) {
+        writeUninstallPlan(allocator, version_dir, resolved.uninstall) catch |receipt_err| {
+            err_out.warn("Could not record uninstall plan for {s}: {s}", .{ resolved.token, @errorName(receipt_err) });
+        };
+    }
+
+    // 5c. Must precede binary staging: a pkg cask's `binary` points at an
+    //     absolute path that does not exist until the package is installed.
+    if (resolved.pkgs.len > 0) {
+        // Baseline: without it a failure cannot tell "installer wrote
+        // something" from "brew installed this earlier".
+        const receipts_before = try receiptPresence(allocator, resolved.uninstall.pkgutil);
+        defer allocator.free(receipts_before);
+
+        for (resolved.pkgs) |pkg| {
+            const pkg_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, pkg.source });
+            defer allocator.free(pkg_path);
+
+            fs.cwd().access(pkg_path, .{}) catch {
+                err_out.err("Package \"{s}\" not found in the downloaded archive.", .{pkg.source});
+                return error.PkgNotFound;
+            };
+
+            out.print("Running installer for {s} (requires sudo)...\n", .{pkg.source});
+            runPkgInstaller(allocator, pkg_path, pkg.allow_untrusted) catch |install_err| {
+                err_out.err("installer failed for \"{s}\": {s}", .{ pkg.source, @errorName(install_err) });
+
+                // A partial run leaves files outside the Caskroom; wiping
+                // version_dir would strand them with no record to undo them.
+                if (anyReceiptAppeared(allocator, resolved.uninstall.pkgutil, receipts_before)) {
+                    commit = true;
+                    err_out.warn(
+                        "{s} is partially installed. Run: bru uninstall {s}",
+                        .{ resolved.token, resolved.token },
+                    );
+                }
+                return install_err;
+            };
+        }
     }
 
     // 6. Stage app bundles into /Applications and leave a back-symlink in
@@ -282,6 +338,483 @@ fn extractZip(allocator: Allocator, zip_path: []const u8, dest_dir: []const u8) 
     }
 }
 
+/// Records how to undo an install. Absent means "nothing to undo beyond
+/// deleting the keg".
+pub const uninstall_plan_file = ".bru-uninstall.json";
+
+/// Stage a bare `.pkg` download into the version dir under the name the cask's
+/// `pkg` artifact declares — the URL basename is not it (often percent-encoded).
+// Clone, not symlink: `bru cleanup` may prune the content-addressed blob store.
+fn stagePkgFile(allocator: Allocator, resolved: ResolvedCask, archive_path: []const u8, dest_dir: []const u8) !void {
+    const name = if (resolved.pkgs.len > 0) resolved.pkgs[0].source else "package.pkg";
+
+    const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, name });
+    defer allocator.free(dest_path);
+
+    if (fs.path.dirname(dest_path)) |parent| try fs.cwd().makePath(parent);
+
+    // clonefile is free on APFS; a pkg can be hundreds of MB.
+    _ = clonefile.cloneTree(archive_path, dest_path) catch {
+        return fs.cwd().copyFile(archive_path, fs.cwd(), dest_path, .{});
+    };
+}
+
+/// Run `args` as root, prefixing sudo unless already root. Returns the exit
+/// code. stdio is inherited so sudo's password prompt stays visible.
+// `Child.run` would capture the prompt and look like a hang.
+fn runAsRoot(allocator: Allocator, args: []const []const u8, quiet: bool) !u8 {
+    var argv = std.ArrayList([]const u8){};
+    defer argv.deinit(allocator);
+    if (std.posix.getuid() != 0) try argv.append(allocator, "sudo");
+    try argv.appendSlice(allocator, args);
+
+    var child = std.process.Child.init(argv.items, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = if (quiet) .Ignore else .Inherit;
+    child.stderr_behavior = if (quiet) .Ignore else .Inherit;
+
+    return switch (try child.spawnAndWait()) {
+        .Exited => |code| code,
+        else => 1,
+    };
+}
+
+/// Hand a package to macOS's installer, as brew's `pkg` artifact does. Needs
+/// root: packages write to /usr/local, /Library, and /var/db/receipts.
+fn runPkgInstaller(allocator: Allocator, pkg_path: []const u8, allow_untrusted: bool) !void {
+    var args = std.ArrayList([]const u8){};
+    defer args.deinit(allocator);
+    try args.append(allocator, "/usr/sbin/installer");
+    if (allow_untrusted) try args.append(allocator, "-allowUntrusted");
+    try args.appendSlice(allocator, &.{ "-pkg", pkg_path, "-target", "/" });
+
+    if (try runAsRoot(allocator, args.items, false) != 0) return error.PkgInstallFailed;
+}
+
+/// Persist the uninstall plan as JSON. `unsupported` is omitted — such casks
+/// never reach install (see the gate in cmd/install.zig).
+fn writeUninstallPlan(allocator: Allocator, version_dir: []const u8, plan: UninstallPlan) !void {
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, uninstall_plan_file });
+    defer allocator.free(path);
+
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(allocator);
+    const writer = buf.writer(allocator);
+
+    try writer.writeAll("{");
+    const sections = [_]struct { name: []const u8, values: [][]const u8 }{
+        .{ .name = "pkgutil", .values = plan.pkgutil },
+        .{ .name = "delete", .values = plan.delete },
+        .{ .name = "trash", .values = plan.trash },
+        .{ .name = "rmdir", .values = plan.rmdir },
+    };
+    for (sections, 0..) |section, i| {
+        if (i > 0) try writer.writeAll(",");
+        try writeJsonStr(writer, section.name);
+        try writer.writeAll(":[");
+        for (section.values, 0..) |value, j| {
+            if (j > 0) try writer.writeAll(",");
+            try writeJsonStr(writer, value);
+        }
+        try writer.writeAll("]");
+    }
+    try writer.writeAll("}\n");
+
+    const file = try fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(buf.items);
+}
+
+/// True when `id` has a receipt registered on this system.
+fn receiptRegistered(allocator: Allocator, id: []const u8) bool {
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "pkgutil", "--pkg-info", id },
+    }) catch return false;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    return switch (result.term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+}
+
+/// Registration state of each ID, positionally. Caller owns the result.
+fn receiptPresence(allocator: Allocator, ids: []const []const u8) ![]bool {
+    const presence = try allocator.alloc(bool, ids.len);
+    for (ids, 0..) |id, i| presence[i] = receiptRegistered(allocator, id);
+    return presence;
+}
+
+/// True when a receipt appeared that `before` did not have — i.e. this run
+/// registered a package and left state worth cleaning up.
+fn anyReceiptAppeared(allocator: Allocator, ids: []const []const u8, before: []const bool) bool {
+    for (ids, before) |id, was_present| {
+        if (!was_present and receiptRegistered(allocator, id)) return true;
+    }
+    return false;
+}
+
+/// Read a version's recorded uninstall plan; empty when none was recorded.
+/// Caller owns the result — release with cask.freeUninstallPlan.
+pub fn readUninstallPlan(allocator: Allocator, version_dir: []const u8) !UninstallPlan {
+    const empty = UninstallPlan{
+        .pkgutil = &.{},
+        .delete = &.{},
+        .rmdir = &.{},
+        .trash = &.{},
+        .unsupported = &.{},
+    };
+
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ version_dir, uninstall_plan_file });
+    defer allocator.free(path);
+
+    const contents = fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch |read_err| switch (read_err) {
+        error.FileNotFound => return empty,
+        else => return read_err,
+    };
+    defer allocator.free(contents);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{ .allocate = .alloc_always });
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return empty,
+    };
+
+    const pkgutil = try json_helpers.parseStringArray(allocator, obj, "pkgutil");
+    errdefer json_helpers.freeStringSlice(allocator, pkgutil);
+    const delete = try json_helpers.parseStringArray(allocator, obj, "delete");
+    errdefer json_helpers.freeStringSlice(allocator, delete);
+    const trash = try json_helpers.parseStringArray(allocator, obj, "trash");
+    errdefer json_helpers.freeStringSlice(allocator, trash);
+    const rmdir = try json_helpers.parseStringArray(allocator, obj, "rmdir");
+
+    return UninstallPlan{
+        .pkgutil = pkgutil,
+        .delete = delete,
+        .rmdir = rmdir,
+        .trash = trash,
+        .unsupported = &.{},
+    };
+}
+
+
+/// Undo a cask version's out-of-Caskroom artifacts, in brew's directive order
+/// so payload files are gone before the directories that held them.
+// Best-effort throughout: one stubborn path must not block the rest.
+pub fn uninstallCaskArtifacts(
+    allocator: Allocator,
+    version_dir: []const u8,
+    out: Output,
+    err_out: Output,
+) void {
+    const plan = readUninstallPlan(allocator, version_dir) catch return;
+    defer cask.freeUninstallPlan(allocator, plan);
+    if (plan.isEmpty()) return;
+
+    for (plan.pkgutil) |id| {
+        // Doubles as the "already gone" check — a re-run, or brew removed it.
+        const root = (pkgReceiptRoot(allocator, id) catch null) orelse continue;
+        defer allocator.free(root);
+
+        out.print("Removing package {s}...\n", .{id});
+
+        removePkgPaths(allocator, id, root, .files) catch |rm_err| {
+            err_out.warn("Could not remove files for {s}: {s}", .{ id, @errorName(rm_err) });
+        };
+        removePkgPaths(allocator, id, root, .dirs) catch {};
+
+        forgetPkgReceipt(allocator, id) catch |forget_err| {
+            err_out.warn("Could not forget receipt {s}: {s}", .{ id, @errorName(forget_err) });
+        };
+    }
+
+    for (plan.delete) |raw| {
+        withExpandedPath(allocator, raw, err_out, deletePath);
+    }
+    for (plan.trash) |raw| {
+        withExpandedPath(allocator, raw, err_out, trashPath);
+    }
+    for (plan.rmdir) |raw| {
+        withExpandedPath(allocator, raw, err_out, rmdirPath);
+    }
+}
+
+/// Expand `raw`, screen it against the system-directory guard, and hand it to
+/// `action`. Paths failing either check are warned about, not acted on.
+fn withExpandedPath(
+    allocator: Allocator,
+    raw: []const u8,
+    err_out: Output,
+    action: *const fn (Allocator, []const u8) anyerror!void,
+) void {
+    const path = expandPath(allocator, raw) catch return;
+    defer allocator.free(path);
+
+    if (!fs.path.isAbsolute(path)) {
+        err_out.warn("Skipping non-absolute uninstall path \"{s}\".", .{raw});
+        return;
+    }
+
+    // Compare the resolved path: a plain string check lets "/usr/local/.." or
+    // a symlinked parent walk straight past the guard, and this runs as root.
+    var real_buf: [fs.max_path_bytes]u8 = undefined;
+    const probe = fs.cwd().realpath(path, &real_buf) catch path;
+    if (isSystemDirectory(probe) or isSystemDirectory(path)) {
+        err_out.warn("Refusing to remove system path \"{s}\".", .{path});
+        return;
+    }
+
+    action(allocator, path) catch |err| {
+        err_out.warn("Could not remove \"{s}\": {s}", .{ path, @errorName(err) });
+    };
+}
+
+/// Resolve `~` and `$HOME` prefixes in a cask-declared path. Caller owns it.
+fn expandPath(allocator: Allocator, raw: []const u8) ![]u8 {
+    const home = std.posix.getenv("HOME") orelse return try allocator.dupe(u8, raw);
+
+    if (mem.eql(u8, raw, "~")) return try allocator.dupe(u8, home);
+    if (mem.startsWith(u8, raw, "~/")) {
+        return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ home, raw[2..] });
+    }
+    if (mem.eql(u8, raw, "$HOME")) return try allocator.dupe(u8, home);
+    if (mem.startsWith(u8, raw, "$HOME/")) {
+        return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ home, raw["$HOME/".len..] });
+    }
+    return try allocator.dupe(u8, raw);
+}
+
+/// Remove a path and anything under it.
+// Unprivileged first, escalating only on permission failure, so a cask owning
+// nothing outside $HOME never prompts for a password.
+fn deletePath(allocator: Allocator, path: []const u8) !void {
+    fs.cwd().access(path, .{}) catch return; // already gone
+    fs.deleteTreeAbsolute(path) catch |err| switch (err) {
+        error.AccessDenied, error.FileBusy, error.ReadOnlyFileSystem => try sudoRemove(allocator, path),
+        else => return err,
+    };
+}
+
+fn sudoRemove(allocator: Allocator, path: []const u8) !void {
+    if (try runAsRoot(allocator, &.{ "/bin/rm", "-rf", "--", path }, false) != 0) {
+        return error.PathRemovalFailed;
+    }
+}
+
+/// Move a path to the user's Trash, as brew's `trash:` does, falling back to
+/// deletion when the move can't be made (cross-volume, root-owned) — as brew does.
+fn trashPath(allocator: Allocator, path: []const u8) !void {
+    fs.cwd().access(path, .{}) catch return; // already gone
+
+    const home = std.posix.getenv("HOME") orelse return deletePath(allocator, path);
+    const base = fs.path.basename(path);
+
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&buf, "{s}/.Trash/{s}", .{ home, base }) catch
+        return deletePath(allocator, path);
+
+    if (fs.cwd().access(dest, .{})) |_| {
+        // Occupied — disambiguate the way Finder does.
+        var buf2: [fs.max_path_bytes]u8 = undefined;
+        const alt = std.fmt.bufPrint(&buf2, "{s}/.Trash/{s} {d}", .{ home, base, std.time.timestamp() }) catch
+            return deletePath(allocator, path);
+        fs.renameAbsolute(path, alt) catch return deletePath(allocator, path);
+        return;
+    } else |_| {}
+
+    fs.renameAbsolute(path, dest) catch return deletePath(allocator, path);
+}
+
+/// Remove a directory only if empty: a populated one is shared with something
+/// else and must stay. That is the whole point of `rmdir:`.
+fn rmdirPath(allocator: Allocator, path: []const u8) !void {
+    _ = allocator;
+    fs.deleteDirAbsolute(path) catch |err| switch (err) {
+        error.DirNotEmpty, error.FileNotFound, error.AccessDenied => {},
+        else => return err,
+    };
+}
+
+/// Prefix a receipt's relative file list is anchored to: `volume` +
+/// `install-location`. Null when no receipt is registered. Caller owns it.
+fn pkgReceiptRoot(allocator: Allocator, id: []const u8) !?[]const u8 {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "pkgutil", "--pkg-info", id },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+
+    var volume: []const u8 = "/";
+    var location: []const u8 = "";
+    var lines = mem.splitScalar(u8, result.stdout, '\n');
+    while (lines.next()) |line| {
+        if (mem.startsWith(u8, line, "volume: ")) {
+            volume = mem.trim(u8, line["volume: ".len..], " \t\r");
+        } else if (mem.startsWith(u8, line, "location: ")) {
+            location = mem.trim(u8, line["location: ".len..], " \t\r/");
+        }
+    }
+
+    if (location.len == 0) return try allocator.dupe(u8, volume);
+    const sep: []const u8 = if (mem.endsWith(u8, volume, "/")) "" else "/";
+    return try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ volume, sep, location });
+}
+
+const PathKind = enum { files, dirs };
+
+/// Delete a receipt's payload paths of one kind, as root, deepest-first and
+/// batched so a large payload cannot overflow the argument list.
+// `rmdir` failing on non-empty dirs is what keeps a shared /usr/local intact.
+fn removePkgPaths(allocator: Allocator, id: []const u8, root: []const u8, kind: PathKind) !void {
+    const only_flag = switch (kind) {
+        .files => "--only-files",
+        .dirs => "--only-dirs",
+    };
+
+    const listing = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "pkgutil", only_flag, "--files", id },
+    });
+    defer allocator.free(listing.stdout);
+    defer allocator.free(listing.stderr);
+    switch (listing.term) {
+        .Exited => |code| if (code != 0) return error.PkgutilListFailed,
+        else => return error.PkgutilListFailed,
+    }
+
+    var paths = std.ArrayList(DepthPath){};
+    defer {
+        for (paths.items) |p| allocator.free(p.path);
+        paths.deinit(allocator);
+    }
+
+    const sep: []const u8 = if (mem.endsWith(u8, root, "/")) "" else "/";
+    var lines = mem.splitScalar(u8, listing.stdout, '\n');
+    while (lines.next()) |line| {
+        const rel = mem.trim(u8, line, " \t\r");
+        if (rel.len == 0 or mem.eql(u8, rel, ".")) continue;
+        const abs = try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ root, sep, rel });
+        // WARNING: runs as root. A BOM legitimately lists its ancestors
+        // (usr, usr/local, Library) — never aim removal at those.
+        if (mem.eql(u8, abs, "/") or abs.len <= root.len or isSystemDirectory(abs)) {
+            allocator.free(abs);
+            continue;
+        }
+        try paths.append(allocator, .{ .depth = mem.count(u8, abs, "/"), .path = abs });
+    }
+    if (paths.items.len == 0) return;
+
+    // Deepest paths first so rmdir sees children before their parents.
+    std.mem.sort(DepthPath, paths.items, {}, deeperPathFirst);
+
+    // rmdir noisily refuses non-empty dirs — expected for shared parents.
+    const cmd: []const []const u8 = switch (kind) {
+        .files => &.{ "/bin/rm", "-f", "--" },
+        .dirs => &.{ "/bin/rmdir", "--" },
+    };
+
+    // Batch by argv bytes rather than a path count: ARG_MAX is ~1 MiB, so a
+    // fixed count of 128 spawns sudo far more often than necessary.
+    const batch_bytes = 256 * 1024;
+    var argv = std.ArrayList([]const u8){};
+    defer argv.deinit(allocator);
+
+    var start: usize = 0;
+    while (start < paths.items.len) {
+        argv.clearRetainingCapacity();
+        try argv.appendSlice(allocator, cmd);
+
+        var bytes: usize = 0;
+        var end = start;
+        while (end < paths.items.len and (end == start or bytes + paths.items[end].path.len + 1 <= batch_bytes)) {
+            bytes += paths.items[end].path.len + 1;
+            end += 1;
+        }
+        for (paths.items[start..end]) |p| try argv.append(allocator, p.path);
+
+        const code = try runAsRoot(allocator, argv.items, kind == .dirs);
+        if (kind == .files and code != 0) return error.PkgFileRemovalFailed;
+
+        start = end;
+    }
+}
+
+/// Directories owned by the OS, not any package — a receipt's BOM lists every
+/// ancestor of its payload, so these appear routinely.
+// rmdir would refuse a populated one anyway; explicit because this runs as root.
+const system_directories = [_][]const u8{
+    "/",
+    "/Applications",
+    "/Library",
+    "/System",
+    "/bin",
+    "/etc",
+    "/opt",
+    "/opt/homebrew",
+    "/opt/homebrew/bin",
+    "/opt/homebrew/lib",
+    "/private",
+    "/sbin",
+    "/tmp",
+    "/usr",
+    "/usr/bin",
+    "/usr/lib",
+    "/usr/libexec",
+    "/usr/local",
+    "/usr/local/bin",
+    "/usr/local/lib",
+    "/usr/local/share",
+    "/usr/sbin",
+    "/usr/share",
+    "/var",
+    "/Users",
+    "/Volumes",
+    // A cask's plist or helper lives *inside* these; the dir itself is macOS's.
+    "/Library/Application Support",
+    "/Library/Audio",
+    "/Library/Caches",
+    "/Library/Fonts",
+    "/Library/Extensions",
+    "/Library/Frameworks",
+    "/Library/Internet Plug-Ins",
+    "/Library/LaunchAgents",
+    "/Library/LaunchDaemons",
+    "/Library/Preferences",
+    "/Library/PrivilegedHelperTools",
+    "/Library/QuickLook",
+    "/Library/Screen Savers",
+};
+
+fn isSystemDirectory(path: []const u8) bool {
+    const trimmed = if (path.len > 1) mem.trimRight(u8, path, "/") else path;
+    for (system_directories) |dir| {
+        if (mem.eql(u8, trimmed, dir)) return true;
+    }
+    return false;
+}
+
+/// Order paths by descending component count so children sort before parents.
+fn deeperPathFirst(_: void, a: DepthPath, b: DepthPath) bool {
+    return a.depth > b.depth;
+}
+
+const DepthPath = struct { depth: usize, path: []const u8 };
+
+/// Drop a receipt so pkgutil no longer reports the package as installed.
+fn forgetPkgReceipt(allocator: Allocator, id: []const u8) !void {
+    if (try runAsRoot(allocator, &.{ "/usr/sbin/pkgutil", "--forget", id }, false) != 0) {
+        return error.PkgForgetFailed;
+    }
+}
+
 /// Extract a tar archive (tar.gz, tar.bz2, tar.xz) using tar.
 fn extractTar(allocator: Allocator, tar_path: []const u8, dest_dir: []const u8) !void {
     const result = try std.process.Child.run(.{
@@ -426,7 +959,12 @@ fn stageBinary(allocator: Allocator, source_roots: []const []const u8, bin_dir: 
     const mode = stat.mode;
     const new_mode = mode | 0o111;
     if (new_mode != mode) {
-        try source_file.chmod(new_mode);
+        // A pkg cask's binary is often root-owned, so chmod may be denied.
+        // The symlink is still worth creating.
+        source_file.chmod(new_mode) catch |chmod_err| switch (chmod_err) {
+            error.AccessDenied => {},
+            else => return chmod_err,
+        };
     }
 
     // Remove existing symlink/file at target.
@@ -442,6 +980,13 @@ fn stageBinary(allocator: Allocator, source_roots: []const []const u8, bin_dir: 
 /// path that exists. Returns error.BinaryNotFound if none match.
 /// Caller owns the returned string.
 fn resolveBinarySource(allocator: Allocator, source_roots: []const []const u8, binary_source: []const u8) ![]u8 {
+    // pkg casks point at files the installer wrote outside the Caskroom;
+    // joining to a root would give "{root}//usr/local/..." and never resolve.
+    if (fs.path.isAbsolute(binary_source)) {
+        fs.cwd().access(binary_source, .{}) catch return error.BinaryNotFound;
+        return try allocator.dupe(u8, binary_source);
+    }
+
     for (source_roots) |root| {
         const candidate = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, binary_source });
         if (fs.cwd().access(candidate, .{})) |_| {
@@ -554,6 +1099,225 @@ test "stageBinary creates symlink and sets executable" {
     // Verify the source is executable.
     const stat = try tmp_version.dir.statFile("my-tool.sh");
     try std.testing.expect((stat.mode & 0o111) != 0);
+}
+
+// ---------------------------------------------------------------------------
+// pkg cask support
+// ---------------------------------------------------------------------------
+
+test "resolveBinarySource returns an absolute source unchanged" {
+    const allocator = std.testing.allocator;
+
+    // Stands in for /usr/local/sessionmanagerplugin/bin/... — nowhere near
+    // the version dir.
+    var installed_tmp = std.testing.tmpDir(.{});
+    defer installed_tmp.cleanup();
+    const f = try installed_tmp.dir.createFile("session-manager-plugin", .{});
+    try f.writeAll("#!/bin/sh\n");
+    f.close();
+
+    var installed_buf: [fs.max_path_bytes]u8 = undefined;
+    const installed_dir = try installed_tmp.dir.realpath(".", &installed_buf);
+    const abs_source = try std.fmt.allocPrint(allocator, "{s}/session-manager-plugin", .{installed_dir});
+    defer allocator.free(abs_source);
+
+    // Roots deliberately do NOT contain the binary — joining would have failed.
+    var version_tmp = std.testing.tmpDir(.{});
+    defer version_tmp.cleanup();
+    var version_buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try version_tmp.dir.realpath(".", &version_buf);
+
+    const roots = [_][]const u8{version_dir};
+    const resolved = try resolveBinarySource(allocator, &roots, abs_source);
+    defer allocator.free(resolved);
+
+    try std.testing.expectEqualStrings(abs_source, resolved);
+}
+
+test "stagePkgFile stages under the declared pkg name, not the URL basename" {
+    const allocator = std.testing.allocator;
+
+    var src_tmp = std.testing.tmpDir(.{});
+    defer src_tmp.cleanup();
+    const blob = try src_tmp.dir.createFile("deadbeef.pkg", .{});
+    try blob.writeAll("xar!payload");
+    blob.close();
+
+    var src_buf: [fs.max_path_bytes]u8 = undefined;
+    const src_dir = try src_tmp.dir.realpath(".", &src_buf);
+    const blob_path = try std.fmt.allocPrint(allocator, "{s}/deadbeef.pkg", .{src_dir});
+    defer allocator.free(blob_path);
+
+    var dest_tmp = std.testing.tmpDir(.{});
+    defer dest_tmp.cleanup();
+    var dest_buf: [fs.max_path_bytes]u8 = undefined;
+    const dest_dir = try dest_tmp.dir.realpath(".", &dest_buf);
+
+    // displaylink's real shape: the URL is percent-encoded, the artifact is not.
+    // Staging from the URL would write "DisplayLink%20Manager.pkg" and then
+    // fail PkgNotFound looking for the declared name.
+    var pkgs = [_]cask.PkgArtifact{.{ .source = "DisplayLink Manager.pkg", .allow_untrusted = false }};
+    const resolved = ResolvedCask{
+        .token = "displaylink",
+        .version = "1.0",
+        .url = "https://example.com/dl/DisplayLink%20Manager.pkg",
+        .sha256 = "abc",
+        .name = "DisplayLink",
+        .binaries = &.{},
+        .apps = &.{},
+        .pkgs = &pkgs,
+        .uninstall = .{ .pkgutil = &.{}, .delete = &.{}, .rmdir = &.{}, .trash = &.{}, .unsupported = &.{} },
+    };
+
+    try stagePkgFile(allocator, resolved, blob_path, dest_dir);
+
+    const staged = try dest_tmp.dir.readFileAlloc(allocator, "DisplayLink Manager.pkg", 1024);
+    defer allocator.free(staged);
+    try std.testing.expectEqualStrings("xar!payload", staged);
+}
+
+test "uninstall plan round-trips through the version dir" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try tmp.dir.realpath(".", &buf);
+
+    // Spaces and tildes are common in real casks; both must survive the trip.
+    const plan = UninstallPlan{
+        .pkgutil = @constCast(&[_][]const u8{ "session-manager-plugin", "com.example.other" }),
+        .delete = @constCast(&[_][]const u8{ "/Library/Application Support/Example", "~/Library/Logs/Ex" }),
+        .rmdir = @constCast(&[_][]const u8{"/Library/Application Support/Example Software"}),
+        .trash = @constCast(&[_][]const u8{"/Library/Audio/Plug-Ins/HAL/Ex.driver"}),
+        .unsupported = @constCast(&[_][]const u8{}),
+    };
+    try writeUninstallPlan(allocator, version_dir, plan);
+
+    const read_back = try readUninstallPlan(allocator, version_dir);
+    defer cask.freeUninstallPlan(allocator, read_back);
+
+    try std.testing.expectEqual(@as(usize, 2), read_back.pkgutil.len);
+    try std.testing.expectEqualStrings("session-manager-plugin", read_back.pkgutil[0]);
+    try std.testing.expectEqual(@as(usize, 2), read_back.delete.len);
+    try std.testing.expectEqualStrings("/Library/Application Support/Example", read_back.delete[0]);
+    try std.testing.expectEqualStrings("~/Library/Logs/Ex", read_back.delete[1]);
+    try std.testing.expectEqual(@as(usize, 1), read_back.rmdir.len);
+    try std.testing.expectEqualStrings("/Library/Application Support/Example Software", read_back.rmdir[0]);
+    try std.testing.expectEqual(@as(usize, 1), read_back.trash.len);
+}
+
+test "readUninstallPlan returns empty when a cask recorded none" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try tmp.dir.realpath(".", &buf);
+
+    // Common app/binary cask: no plan file at all.
+    const plan = try readUninstallPlan(allocator, version_dir);
+    defer cask.freeUninstallPlan(allocator, plan);
+    try std.testing.expect(plan.isEmpty());
+}
+
+test "expandPath resolves tilde and $HOME prefixes" {
+    const allocator = std.testing.allocator;
+    const home = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+
+    const tilde = try expandPath(allocator, "~/Library/Logs/Ex");
+    defer allocator.free(tilde);
+    const expected = try std.fmt.allocPrint(allocator, "{s}/Library/Logs/Ex", .{home});
+    defer allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, tilde);
+
+    const dollar = try expandPath(allocator, "$HOME/Library/Logs/Ex");
+    defer allocator.free(dollar);
+    try std.testing.expectEqualStrings(expected, dollar);
+
+    // "~name" is another user, NOT a home reference.
+    const abs = try expandPath(allocator, "/Library/Application Support/Ex");
+    defer allocator.free(abs);
+    try std.testing.expectEqualStrings("/Library/Application Support/Ex", abs);
+
+    const other_user = try expandPath(allocator, "~someone/thing");
+    defer allocator.free(other_user);
+    try std.testing.expectEqualStrings("~someone/thing", other_user);
+}
+
+test "deletePath and rmdirPath remove only what they should" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const root = try tmp.dir.realpath(".", &buf);
+
+    // delete: removes a whole tree.
+    try tmp.dir.makePath("support/nested");
+    const f = try tmp.dir.createFile("support/nested/file", .{});
+    f.close();
+    const support = try std.fmt.allocPrint(allocator, "{s}/support", .{root});
+    defer allocator.free(support);
+    try deletePath(allocator, support);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("support", .{}));
+
+    // delete: on a missing path is a no-op, not an error (re-run uninstall).
+    try deletePath(allocator, support);
+
+    // rmdir: removes an empty directory...
+    try tmp.dir.makeDir("empty");
+    const empty = try std.fmt.allocPrint(allocator, "{s}/empty", .{root});
+    defer allocator.free(empty);
+    try rmdirPath(allocator, empty);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("empty", .{}));
+
+    // ...but leaves a populated one alone; it is shared.
+    try tmp.dir.makePath("occupied");
+    const keep = try tmp.dir.createFile("occupied/other-owner", .{});
+    keep.close();
+    const occupied = try std.fmt.allocPrint(allocator, "{s}/occupied", .{root});
+    defer allocator.free(occupied);
+    try rmdirPath(allocator, occupied);
+    try tmp.dir.access("occupied/other-owner", .{});
+}
+
+test "isSystemDirectory shields OS directories from rmdir" {
+    // All of these appear in session-manager-plugin's own BOM.
+    try std.testing.expect(isSystemDirectory("/usr"));
+    try std.testing.expect(isSystemDirectory("/usr/local"));
+    try std.testing.expect(isSystemDirectory("/Library"));
+    try std.testing.expect(isSystemDirectory("/"));
+    try std.testing.expect(isSystemDirectory("/usr/local/"));
+
+    // Only the plist inside belongs to the package, not the dir.
+    try std.testing.expect(isSystemDirectory("/Library/LaunchDaemons"));
+
+    // Package-owned directories must remain removable.
+    try std.testing.expect(!isSystemDirectory("/usr/local/sessionmanagerplugin"));
+    try std.testing.expect(!isSystemDirectory("/usr/local/sessionmanagerplugin/bin"));
+    try std.testing.expect(!isSystemDirectory("/Library/LaunchDaemons/SessionManagerPlugin.plist"));
+}
+
+test "deeperPathFirst sorts children before their parents" {
+    const mk = struct {
+        fn f(p: []const u8) DepthPath {
+            return .{ .depth = mem.count(u8, p, "/"), .path = p };
+        }
+    }.f;
+    var paths = [_]DepthPath{
+        mk("/usr/local"),
+        mk("/usr/local/sessionmanagerplugin/bin/session-manager-plugin"),
+        mk("/usr/local/sessionmanagerplugin"),
+        mk("/usr/local/sessionmanagerplugin/bin"),
+    };
+    std.mem.sort(DepthPath, &paths, {}, deeperPathFirst);
+
+    // Otherwise every parent removal fails as non-empty.
+    try std.testing.expectEqualStrings("/usr/local/sessionmanagerplugin/bin/session-manager-plugin", paths[0].path);
+    try std.testing.expectEqualStrings("/usr/local/sessionmanagerplugin/bin", paths[1].path);
+    try std.testing.expectEqualStrings("/usr/local/sessionmanagerplugin", paths[2].path);
+    try std.testing.expectEqualStrings("/usr/local", paths[3].path);
 }
 
 test "stageBinary returns error for missing binary" {

--- a/src/cask_install.zig
+++ b/src/cask_install.zig
@@ -102,8 +102,10 @@ pub fn installCask(
     //     for pkg casks; app casks are left with their prior behaviour rather
     //     than gaining half a teardown from this change.
     if (resolved.pkgs.len > 0 and !resolved.uninstall.isEmpty()) {
-        writeUninstallPlan(allocator, version_dir, resolved.uninstall) catch |receipt_err| {
-            err_out.warn("Could not record uninstall plan for {s}: {s}", .{ resolved.token, @errorName(receipt_err) });
+        writeUninstallPlan(allocator, version_dir, resolved.uninstall) catch |plan_err| {
+            err_out.err("Could not record the uninstall plan for {s}: {s}", .{ resolved.token, @errorName(plan_err) });
+            err_out.print("Not running installer — without this file bru could not undo the install.\n", .{});
+            return plan_err;
         };
     }
 
@@ -125,13 +127,14 @@ pub fn installCask(
             };
 
             out.print("Running installer for {s} (requires sudo)...\n", .{pkg.source});
+
+            // From here the system may have been mutated, so keep version_dir
+            // (and the plan inside it) regardless of how this turns out.
+            commit = true;
             runPkgInstaller(allocator, pkg_path, pkg.allow_untrusted) catch |install_err| {
                 err_out.err("installer failed for \"{s}\": {s}", .{ pkg.source, @errorName(install_err) });
 
-                // A partial run leaves files outside the Caskroom; wiping
-                // version_dir would strand them with no record to undo them.
                 if (anyReceiptAppeared(allocator, resolved.uninstall.pkgutil, receipts_before)) {
-                    commit = true;
                     err_out.warn(
                         "{s} is partially installed. Run: bru uninstall {s}",
                         .{ resolved.token, resolved.token },
@@ -342,6 +345,14 @@ fn extractZip(allocator: Allocator, zip_path: []const u8, dest_dir: []const u8) 
 /// deleting the keg".
 pub const uninstall_plan_file = ".bru-uninstall.json";
 
+/// WARNING: absolute, never PATH-resolved. This tool's output builds the argv
+/// for a root `rm`, and user-writable dirs routinely precede /usr/sbin in PATH.
+const pkgutil_bin = "/usr/sbin/pkgutil";
+
+/// `pkgutil --files` prints one path per line; Child.run's 50 KiB default
+/// truncates any package with an .app bundle into StdoutStreamTooLong.
+const pkgutil_max_output = 16 * 1024 * 1024;
+
 /// Stage a bare `.pkg` download into the version dir under the name the cask's
 /// `pkg` artifact declares — the URL basename is not it (often percent-encoded).
 // Clone, not symlink: `bru cleanup` may prune the content-addressed blob store.
@@ -429,7 +440,7 @@ fn writeUninstallPlan(allocator: Allocator, version_dir: []const u8, plan: Unins
 fn receiptRegistered(allocator: Allocator, id: []const u8) bool {
     const result = std.process.Child.run(.{
         .allocator = allocator,
-        .argv = &.{ "pkgutil", "--pkg-info", id },
+        .argv = &.{ pkgutil_bin, "--pkg-info", id },
     }) catch return false;
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
@@ -501,45 +512,80 @@ pub fn readUninstallPlan(allocator: Allocator, version_dir: []const u8) !Uninsta
 }
 
 
+/// True when this version dir carries an uninstall plan bru wrote.
+pub fn hasUninstallPlan(version_dir: []const u8) bool {
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&buf, "{s}/{s}", .{ version_dir, uninstall_plan_file }) catch return false;
+    fs.cwd().access(path, .{}) catch return false;
+    return true;
+}
+
+/// True when brew owns this cask: it writes `.metadata` beside the version dir
+/// and bru never does.
+pub fn looksBrewInstalled(version_dir: []const u8) bool {
+    const parent = fs.path.dirname(version_dir) orelse return false;
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&buf, "{s}/.metadata", .{parent}) catch return false;
+    fs.cwd().access(path, .{}) catch return false;
+    return true;
+}
+
 /// Undo a cask version's out-of-Caskroom artifacts, in brew's directive order
 /// so payload files are gone before the directories that held them.
-// Best-effort throughout: one stubborn path must not block the rest.
+///
+/// Returns the number of artifacts that could not be removed. Callers must not
+/// report a clean uninstall, or delete the keg, when this is non-zero — the
+/// keg holds the only record of what was installed as root.
 pub fn uninstallCaskArtifacts(
     allocator: Allocator,
     version_dir: []const u8,
     out: Output,
     err_out: Output,
-) void {
-    const plan = readUninstallPlan(allocator, version_dir) catch return;
+) error{UninstallPlanUnreadable}!usize {
+    // An unreadable plan is NOT "nothing to undo": a truncated write looks
+    // exactly like this, and the caller would delete the only manifest.
+    const plan = readUninstallPlan(allocator, version_dir) catch |read_err| {
+        err_out.err("Could not read the uninstall plan in {s}: {s}", .{ version_dir, @errorName(read_err) });
+        err_out.print("Refusing to remove the keg — it records what this cask installed as root.\n", .{});
+        return error.UninstallPlanUnreadable;
+    };
     defer cask.freeUninstallPlan(allocator, plan);
-    if (plan.isEmpty()) return;
+    if (plan.isEmpty()) return 0;
+
+    var failures: usize = 0;
 
     for (plan.pkgutil) |id| {
-        // Doubles as the "already gone" check — a re-run, or brew removed it.
-        const root = (pkgReceiptRoot(allocator, id) catch null) orelse continue;
+        const root = pkgReceiptRoot(allocator, id) catch |query_err| {
+            err_out.err("Could not query receipt {s}: {s} — its files were left in place.", .{ id, @errorName(query_err) });
+            failures += 1;
+            continue;
+        } orelse continue; // genuinely not registered: a re-run, or brew removed it
         defer allocator.free(root);
 
         out.print("Removing package {s}...\n", .{id});
 
-        removePkgPaths(allocator, id, root, .files) catch |rm_err| {
-            err_out.warn("Could not remove files for {s}: {s}", .{ id, @errorName(rm_err) });
-        };
-        removePkgPaths(allocator, id, root, .dirs) catch {};
-
-        forgetPkgReceipt(allocator, id) catch |forget_err| {
-            err_out.warn("Could not forget receipt {s}: {s}", .{ id, @errorName(forget_err) });
-        };
+        if (removePkgPaths(allocator, id, root, .files)) |_| {
+            removePkgPaths(allocator, id, root, .dirs) catch |dir_err| {
+                err_out.warn("Could not remove empty dirs for {s}: {s}", .{ id, @errorName(dir_err) });
+            };
+            forgetPkgReceipt(allocator, id) catch |forget_err| {
+                err_out.warn("Could not forget receipt {s}: {s}", .{ id, @errorName(forget_err) });
+                failures += 1;
+            };
+        } else |rm_err| {
+            // Keep the receipt: `pkgutil --files` is the only way to enumerate
+            // what was left behind, and --forget destroys that manifest.
+            err_out.err("Could not remove files for {s}: {s}", .{ id, @errorName(rm_err) });
+            err_out.print("Keeping the receipt so `pkgutil --files {s}` can still list them.\n", .{id});
+            failures += 1;
+        }
     }
 
-    for (plan.delete) |raw| {
-        withExpandedPath(allocator, raw, err_out, deletePath);
-    }
-    for (plan.trash) |raw| {
-        withExpandedPath(allocator, raw, err_out, trashPath);
-    }
-    for (plan.rmdir) |raw| {
-        withExpandedPath(allocator, raw, err_out, rmdirPath);
-    }
+    for (plan.delete) |raw| failures += withExpandedPath(allocator, raw, err_out, deletePath);
+    for (plan.trash) |raw| failures += withExpandedPath(allocator, raw, err_out, trashPath);
+    for (plan.rmdir) |raw| failures += withExpandedPath(allocator, raw, err_out, rmdirPath);
+
+    return failures;
 }
 
 /// Expand `raw`, screen it against the system-directory guard, and hand it to
@@ -549,31 +595,52 @@ fn withExpandedPath(
     raw: []const u8,
     err_out: Output,
     action: *const fn (Allocator, []const u8) anyerror!void,
-) void {
-    const path = expandPath(allocator, raw) catch return;
+) usize {
+    const path = expandPath(allocator, raw) catch |err| {
+        err_out.warn("Could not expand uninstall path \"{s}\": {s}", .{ raw, @errorName(err) });
+        return 1;
+    };
     defer allocator.free(path);
 
     if (!fs.path.isAbsolute(path)) {
         err_out.warn("Skipping non-absolute uninstall path \"{s}\".", .{raw});
-        return;
+        return 1;
     }
 
     // Compare the resolved path: a plain string check lets "/usr/local/.." or
     // a symlinked parent walk straight past the guard, and this runs as root.
     var real_buf: [fs.max_path_bytes]u8 = undefined;
-    const probe = fs.cwd().realpath(path, &real_buf) catch path;
+    const probe = fs.cwd().realpath(path, &real_buf) catch |err| switch (err) {
+        // Nothing there to remove.
+        error.FileNotFound => return 0,
+        // Guard degraded to a plain string compare — decline rather than
+        // run `rm -rf` as root on a path we could not resolve.
+        else => {
+            err_out.warn("Could not resolve \"{s}\" ({s}); leaving it in place.", .{ path, @errorName(err) });
+            return 1;
+        },
+    };
     if (isSystemDirectory(probe) or isSystemDirectory(path)) {
         err_out.warn("Refusing to remove system path \"{s}\".", .{path});
-        return;
+        return 1;
     }
 
     action(allocator, path) catch |err| {
         err_out.warn("Could not remove \"{s}\": {s}", .{ path, @errorName(err) });
+        return 1;
     };
+    return 0;
 }
 
 /// Resolve `~` and `$HOME` prefixes in a cask-declared path. Caller owns it.
 fn expandPath(allocator: Allocator, raw: []const u8) ![]u8 {
+    const tilde = mem.startsWith(u8, raw, "~") or mem.startsWith(u8, raw, "$HOME");
+    if (tilde and std.posix.getuid() == 0) {
+        // HOME is /var/root under sudo; expanding would target the wrong user
+        // and silently remove nothing.
+        return error.HomeRelativePathAsRoot;
+    }
+
     const home = std.posix.getenv("HOME") orelse return try allocator.dupe(u8, raw);
 
     if (mem.eql(u8, raw, "~")) return try allocator.dupe(u8, home);
@@ -591,9 +658,13 @@ fn expandPath(allocator: Allocator, raw: []const u8) ![]u8 {
 // Unprivileged first, escalating only on permission failure, so a cask owning
 // nothing outside $HOME never prompts for a password.
 fn deletePath(allocator: Allocator, path: []const u8) !void {
-    fs.cwd().access(path, .{}) catch return; // already gone
     fs.deleteTreeAbsolute(path) catch |err| switch (err) {
-        error.AccessDenied, error.FileBusy, error.ReadOnlyFileSystem => try sudoRemove(allocator, path),
+        error.FileNotFound => {},
+        error.AccessDenied,
+        error.PermissionDenied,
+        error.FileBusy,
+        error.ReadOnlyFileSystem,
+        => try sudoRemove(allocator, path),
         else => return err,
     };
 }
@@ -604,28 +675,33 @@ fn sudoRemove(allocator: Allocator, path: []const u8) !void {
     }
 }
 
-/// Move a path to the user's Trash, as brew's `trash:` does, falling back to
-/// deletion when the move can't be made (cross-volume, root-owned) — as brew does.
+/// Move a path to the user's Trash, as brew's `trash:` does.
+// Reports failure rather than deleting: `trash:` means the user may want these
+// back, so a silent permanent delete is the one outcome to avoid.
 fn trashPath(allocator: Allocator, path: []const u8) !void {
+    _ = allocator;
     fs.cwd().access(path, .{}) catch return; // already gone
 
-    const home = std.posix.getenv("HOME") orelse return deletePath(allocator, path);
-    const base = fs.path.basename(path);
+    // `trash:` exists so the user can get these back. Every fall-through below
+    // is a permanent delete, so none of them may happen quietly.
+    const home = std.posix.getenv("HOME") orelse {
+        return error.TrashUnavailable;
+    };
 
+    const base = fs.path.basename(path);
     var buf: [fs.max_path_bytes]u8 = undefined;
     const dest = std.fmt.bufPrint(&buf, "{s}/.Trash/{s}", .{ home, base }) catch
-        return deletePath(allocator, path);
+        return error.TrashUnavailable;
 
     if (fs.cwd().access(dest, .{})) |_| {
         // Occupied — disambiguate the way Finder does.
         var buf2: [fs.max_path_bytes]u8 = undefined;
         const alt = std.fmt.bufPrint(&buf2, "{s}/.Trash/{s} {d}", .{ home, base, std.time.timestamp() }) catch
-            return deletePath(allocator, path);
-        fs.renameAbsolute(path, alt) catch return deletePath(allocator, path);
-        return;
+            return error.TrashUnavailable;
+        return fs.renameAbsolute(path, alt);
     } else |_| {}
 
-    fs.renameAbsolute(path, dest) catch return deletePath(allocator, path);
+    try fs.renameAbsolute(path, dest);
 }
 
 /// Remove a directory only if empty: a populated one is shared with something
@@ -643,7 +719,7 @@ fn rmdirPath(allocator: Allocator, path: []const u8) !void {
 fn pkgReceiptRoot(allocator: Allocator, id: []const u8) !?[]const u8 {
     const result = try std.process.Child.run(.{
         .allocator = allocator,
-        .argv = &.{ "pkgutil", "--pkg-info", id },
+        .argv = &.{ pkgutil_bin, "--pkg-info", id },
     });
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
@@ -681,7 +757,8 @@ fn removePkgPaths(allocator: Allocator, id: []const u8, root: []const u8, kind: 
 
     const listing = try std.process.Child.run(.{
         .allocator = allocator,
-        .argv = &.{ "pkgutil", only_flag, "--files", id },
+        .argv = &.{ pkgutil_bin, only_flag, "--files", id },
+        .max_output_bytes = pkgutil_max_output,
     });
     defer allocator.free(listing.stdout);
     defer allocator.free(listing.stderr);
@@ -732,12 +809,7 @@ fn removePkgPaths(allocator: Allocator, id: []const u8, root: []const u8, kind: 
         argv.clearRetainingCapacity();
         try argv.appendSlice(allocator, cmd);
 
-        var bytes: usize = 0;
-        var end = start;
-        while (end < paths.items.len and (end == start or bytes + paths.items[end].path.len + 1 <= batch_bytes)) {
-            bytes += paths.items[end].path.len + 1;
-            end += 1;
-        }
+        const end = nextBatchEnd(paths.items, start, batch_bytes);
         for (paths.items[start..end]) |p| try argv.append(allocator, p.path);
 
         const code = try runAsRoot(allocator, argv.items, kind == .dirs);
@@ -798,7 +870,47 @@ fn isSystemDirectory(path: []const u8) bool {
     for (system_directories) |dir| {
         if (mem.eql(u8, trimmed, dir)) return true;
     }
+    return isProtectedHomeDirectory(trimmed);
+}
+
+/// $HOME itself and the top-level user directories. No shipping cask names
+/// these, but the guard's job is to bound what third-party metadata can hand
+/// to a root `rm`, and these are where the most is lost.
+fn isProtectedHomeDirectory(path: []const u8) bool {
+    const home = std.posix.getenv("HOME") orelse return false;
+    if (mem.eql(u8, path, home)) return true;
+
+    if (!mem.startsWith(u8, path, home)) return false;
+    const rest = path[home.len..];
+    if (rest.len == 0 or rest[0] != '/') return false;
+
+    const protected = [_][]const u8{
+        "Library",                   "Library/Application Support",
+        "Library/Caches",            "Library/Preferences",
+        "Library/Containers",        "Library/LaunchAgents",
+        "Documents",                 "Desktop",
+        "Downloads",                 "Movies",
+        "Music",                     "Pictures",
+        "Applications",              ".Trash",
+    };
+    for (protected) |p| {
+        if (mem.eql(u8, rest[1..], p)) return true;
+    }
     return false;
+}
+
+/// Index one past the last path that fits in `budget` bytes of argv, starting
+/// at `start`. Always advances by at least one so no path is ever skipped,
+/// even when a single path exceeds the budget on its own.
+fn nextBatchEnd(paths: []const DepthPath, start: usize, budget: usize) usize {
+    var bytes: usize = 0;
+    var end = start;
+    while (end < paths.len) : (end += 1) {
+        const cost = paths[end].path.len + 1;
+        if (end > start and bytes + cost > budget) break;
+        bytes += cost;
+    }
+    return end;
 }
 
 /// Order paths by descending component count so children sort before parents.
@@ -810,7 +922,7 @@ const DepthPath = struct { depth: usize, path: []const u8 };
 
 /// Drop a receipt so pkgutil no longer reports the package as installed.
 fn forgetPkgReceipt(allocator: Allocator, id: []const u8) !void {
-    if (try runAsRoot(allocator, &.{ "/usr/sbin/pkgutil", "--forget", id }, false) != 0) {
+    if (try runAsRoot(allocator, &.{ pkgutil_bin, "--forget", id }, false) != 0) {
         return error.PkgForgetFailed;
     }
 }
@@ -1052,13 +1164,6 @@ test "sniffArchiveKind returns unknown for unrecognized data" {
     try std.testing.expectEqual(ArchiveKind.unknown, try sniffArchiveKind(path));
 }
 
-test "cask_install compiles" {
-    // Verify this module compiles and links correctly.
-    _ = installCask;
-    _ = extractZip;
-    _ = extractTar;
-}
-
 test "stageBinary creates symlink and sets executable" {
     const allocator = std.testing.allocator;
 
@@ -1297,6 +1402,164 @@ test "isSystemDirectory shields OS directories from rmdir" {
     try std.testing.expect(!isSystemDirectory("/usr/local/sessionmanagerplugin"));
     try std.testing.expect(!isSystemDirectory("/usr/local/sessionmanagerplugin/bin"));
     try std.testing.expect(!isSystemDirectory("/Library/LaunchDaemons/SessionManagerPlugin.plist"));
+}
+
+test "isSystemDirectory shields the home directory and its top-level dirs" {
+    const home = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+
+    try std.testing.expect(isSystemDirectory(home));
+
+    for ([_][]const u8{ "Library", "Documents", "Library/Application Support", ".Trash" }) |sub| {
+        const p = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ home, sub });
+        defer allocator.free(p);
+        try std.testing.expect(isSystemDirectory(p));
+    }
+
+    // A cask's own directory under ~/Library stays removable.
+    const own = try std.fmt.allocPrint(allocator, "{s}/Library/Application Support/SomeVendor", .{home});
+    defer allocator.free(own);
+    try std.testing.expect(!isSystemDirectory(own));
+
+    // A sibling that merely shares the prefix is not the home dir.
+    const sibling = try std.fmt.allocPrint(allocator, "{s}-other/Library", .{home});
+    defer allocator.free(sibling);
+    try std.testing.expect(!isSystemDirectory(sibling));
+}
+
+test "expandPath refuses home-relative paths when running as root" {
+    if (std.posix.getuid() == 0) return error.SkipZigTest;
+    _ = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+
+    // Non-root: expansion works (covered elsewhere). The root refusal exists
+    // because HOME is /var/root under sudo, so expanding would target the
+    // wrong user and silently remove nothing while reporting success.
+    const allocator = std.testing.allocator;
+    const p = try expandPath(allocator, "~/Library/Logs/Ex");
+    defer allocator.free(p);
+    try std.testing.expect(fs.path.isAbsolute(p));
+}
+
+test "keg ownership decides whether uninstall may delete it" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const root = try tmp.dir.realpath(".", &buf);
+
+    const allocator = std.testing.allocator;
+    const version_dir = try std.fmt.allocPrint(allocator, "{s}/token/1.0", .{root});
+    defer allocator.free(version_dir);
+    try fs.cwd().makePath(version_dir);
+
+    // A bru-installed app cask: no plan, no brew metadata -> safe to delete.
+    try std.testing.expect(!hasUninstallPlan(version_dir));
+    try std.testing.expect(!looksBrewInstalled(version_dir));
+
+    // brew writes .metadata beside the version dir; bru never does. Deleting
+    // this keg would destroy the entry brew needs to clean up.
+    const meta = try std.fmt.allocPrint(allocator, "{s}/token/.metadata", .{root});
+    defer allocator.free(meta);
+    try fs.cwd().makePath(meta);
+    try std.testing.expect(looksBrewInstalled(version_dir));
+
+    // A recorded plan means bru owns the teardown even if brew touched it.
+    var plan_ids = [_][]const u8{"com.example.a"};
+    const plan = UninstallPlan{ .pkgutil = &plan_ids, .delete = &.{}, .rmdir = &.{}, .trash = &.{}, .unsupported = &.{} };
+    try writeUninstallPlan(allocator, version_dir, plan);
+    try std.testing.expect(hasUninstallPlan(version_dir));
+}
+
+test "an unreadable plan refuses the uninstall instead of reporting success" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const version_dir = try tmp.dir.realpath(".", &buf);
+
+    // A truncated write looks exactly like this. Treating it as "nothing to
+    // undo" would let the caller delete the only manifest for a root payload.
+    const f = try tmp.dir.createFile(uninstall_plan_file, .{});
+    try f.writeAll("{\"pkgutil\":[\"com.example.a\"");
+    f.close();
+
+    try std.testing.expectError(error.UnexpectedEndOfInput, readUninstallPlan(allocator, version_dir));
+
+    const quiet = Output{ .file = std.fs.File.stderr(), .use_color = false };
+    try std.testing.expectError(
+        error.UninstallPlanUnreadable,
+        uninstallCaskArtifacts(allocator, version_dir, quiet, quiet),
+    );
+}
+
+test "uninstallCaskArtifacts applies delete then rmdir, and refuses system paths" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [fs.max_path_bytes]u8 = undefined;
+    const root = try tmp.dir.realpath(".", &buf);
+
+    try tmp.dir.makePath("payload/nested");
+    const f = try tmp.dir.createFile("payload/nested/file", .{});
+    f.close();
+    try tmp.dir.makePath("empty");
+    try tmp.dir.makePath("occupied");
+    const keep = try tmp.dir.createFile("occupied/other-owner", .{});
+    keep.close();
+
+    const payload = try std.fmt.allocPrint(allocator, "{s}/payload", .{root});
+    defer allocator.free(payload);
+    const empty = try std.fmt.allocPrint(allocator, "{s}/empty", .{root});
+    defer allocator.free(empty);
+    const occupied = try std.fmt.allocPrint(allocator, "{s}/occupied", .{root});
+    defer allocator.free(occupied);
+
+    // A cask aiming at a system directory must be refused, not obeyed: this
+    // list is the only thing between remote metadata and a root `rm -rf`.
+    var deletes = [_][]const u8{ payload, "/usr/local" };
+    var rmdirs = [_][]const u8{ empty, occupied };
+    // An id no receipt matches, so the pkgutil branch short-circuits (no sudo).
+    var ids = [_][]const u8{"com.bru.test.absent"};
+
+    const plan = UninstallPlan{ .pkgutil = &ids, .delete = &deletes, .rmdir = &rmdirs, .trash = &.{}, .unsupported = &.{} };
+    try writeUninstallPlan(allocator, root, plan);
+
+    const quiet = Output{ .file = std.fs.File.stderr(), .use_color = false };
+    const failures = try uninstallCaskArtifacts(allocator, root, quiet, quiet);
+
+    // The refused system path is reported, not silently skipped.
+    try std.testing.expectEqual(@as(usize, 1), failures);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("payload", .{}));
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("empty", .{}));
+    try tmp.dir.access("occupied/other-owner", .{}); // shared dir survives
+    try fs.cwd().access("/usr/local", .{}); // untouched
+}
+
+test "nextBatchEnd always advances and never exceeds its budget" {
+    const paths = [_]DepthPath{
+        .{ .depth = 1, .path = "/aaaa" }, // 5 + 1
+        .{ .depth = 1, .path = "/bbbb" },
+        .{ .depth = 1, .path = "/cccc" },
+    };
+
+    // Budget fits exactly two entries (6 bytes each).
+    try std.testing.expectEqual(@as(usize, 2), nextBatchEnd(&paths, 0, 12));
+    try std.testing.expectEqual(@as(usize, 3), nextBatchEnd(&paths, 2, 12));
+
+    // A budget too small for even one path must still consume one, or the
+    // caller loops forever and the remaining paths are never removed.
+    try std.testing.expectEqual(@as(usize, 1), nextBatchEnd(&paths, 0, 1));
+
+    // Walking the whole list covers every path exactly once.
+    var start: usize = 0;
+    var seen: usize = 0;
+    while (start < paths.len) {
+        const end = nextBatchEnd(&paths, start, 7);
+        try std.testing.expect(end > start);
+        seen += end - start;
+        start = end;
+    }
+    try std.testing.expectEqual(paths.len, seen);
 }
 
 test "deeperPathFirst sorts children before their parents" {

--- a/src/cmd/install.zig
+++ b/src/cmd/install.zig
@@ -396,15 +396,27 @@ fn installCaskCmd(allocator: Allocator, name: []const u8, config: Config, out: O
     };
     defer cask_mod.freeResolvedCask(allocator, resolved);
 
-    // Only bail when the cask declares neither CLI binaries nor app
-    // bundles — those are the two artifact kinds bru can install. (Casks
-    // limited to `pkg`/`installer`/`font` artifacts still fall through to
-    // a real brew install via the `Use: brew install --cask ...` hint.)
-    if (resolved.binaries.len == 0 and resolved.apps.len == 0) {
-        err_out.warn("No installable artifacts for cask \"{s}\".", .{name});
-        err_out.print("This cask uses an artifact type bru can't handle yet (e.g. pkg, font).\n", .{});
-        err_out.print("Use: brew install --cask {s}\n", .{name});
-        return;
+    switch (cask_mod.installability(resolved)) {
+        .ok => {},
+        .no_artifacts => {
+            err_out.warn("No installable artifacts for cask \"{s}\".", .{name});
+            err_out.print("This cask uses an artifact type bru can't handle yet (e.g. font, installer).\n", .{});
+            err_out.print("Use: brew install --cask {s}\n", .{name});
+            return;
+        },
+        // The `uninstall` stanza is the only description of how to take a
+        // root-installed pkg back out. If bru can't perform it, installing
+        // here would leave the user something only brew can remove.
+        .unremovable => {
+            // No defer: execBrew is noreturn.
+            const directives = std.mem.join(allocator, ", ", resolved.uninstall.unsupported) catch "";
+            err_out.warn(
+                "Cask \"{s}\" needs uninstall steps bru doesn't support yet: {s}.",
+                .{ name, directives },
+            );
+            err_out.print("Deferring to brew so it stays uninstallable.\n", .{});
+            fallback.execBrew(allocator, &.{ "bru", "install", "--cask", name });
+        },
     }
 
     // Run the cask install pipeline.

--- a/src/cmd/uninstall.zig
+++ b/src/cmd/uninstall.zig
@@ -5,6 +5,7 @@ const Config = @import("../config.zig").Config;
 const Cellar = @import("../cellar.zig").Cellar;
 const Linker = @import("../linker.zig").Linker;
 const Output = @import("../output.zig").Output;
+const cask_install = @import("../cask_install.zig");
 
 /// Uninstall one or more formulae by unlinking from the prefix and removing kegs.
 ///
@@ -58,11 +59,15 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
         // Get installed versions — check cellar first, then caskroom.
         const cellar = Cellar.init(config.cellar);
         var base_path = config.cellar;
+        var is_cask = false;
         var versions = cellar.installedVersions(allocator, name);
         if (versions == null) {
             const caskroom = Cellar.init(config.caskroom);
             versions = caskroom.installedVersions(allocator, name);
-            if (versions != null) base_path = config.caskroom;
+            if (versions != null) {
+                base_path = config.caskroom;
+                is_cask = true;
+            }
         }
         const installed_versions = versions orelse {
             err_out.err("{s} is not installed.", .{name});
@@ -87,6 +92,14 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
             linker.unlink(keg_path) catch |link_err| {
                 out.warn("Failed to unlink {s} {s}: {s}", .{ name, version, @errorName(link_err) });
             };
+
+            // A cask can install outside the Caskroom — a `pkg` payload under
+            // /usr/local, support files named by `delete:`/`trash:`. Deleting
+            // the keg alone would leave those behind, so undo them while the
+            // keg, which holds the recorded uninstall plan, still exists.
+            if (is_cask) {
+                cask_install.uninstallCaskArtifacts(allocator, keg_path, out, err_out);
+            }
 
             // Delete the keg directory tree.
             fs.deleteTreeAbsolute(keg_path) catch |del_err| {

--- a/src/cmd/uninstall.zig
+++ b/src/cmd/uninstall.zig
@@ -48,6 +48,8 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
     const out = Output.init(config.no_color);
     const err_out = Output.initErr(config.no_color);
 
+    var had_failure = false;
+
     // 3. Process each formula name.
     for (parsed.formula_names.items) |raw_name| {
         // Extract simple name from tap-prefixed names (e.g. "user/tap/pkg" -> "pkg").
@@ -81,6 +83,8 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
         // Set up linker.
         var linker = Linker.init(allocator, config.prefix);
 
+        var artifact_failures: usize = 0;
+
         // For each version: unlink, then delete keg directory.
         for (installed_versions) |version| {
             var keg_buf: [fs.max_path_bytes]u8 = undefined;
@@ -98,12 +102,31 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
             // the keg alone would leave those behind, so undo them while the
             // keg, which holds the recorded uninstall plan, still exists.
             if (is_cask) {
-                cask_install.uninstallCaskArtifacts(allocator, keg_path, out, err_out);
+                // A brew-installed cask has no plan of ours. Deleting its keg
+                // would destroy the entry brew needs to clean up, leaving the
+                // payload removable by neither tool.
+                if (!cask_install.hasUninstallPlan(keg_path) and cask_install.looksBrewInstalled(keg_path)) {
+                    err_out.warn("{s} {s} was installed by brew; bru has no record of its payload.", .{ name, version });
+                    err_out.print("Use: brew uninstall --cask {s}\n", .{name});
+                    artifact_failures += 1;
+                    continue;
+                }
+
+                const failures = cask_install.uninstallCaskArtifacts(allocator, keg_path, out, err_out) catch {
+                    artifact_failures += 1;
+                    continue; // keg intentionally left in place
+                };
+                if (failures > 0) {
+                    artifact_failures += failures;
+                    err_out.err("{s} {s}: {d} artifact(s) left on disk — keeping the keg as the record.", .{ name, version, failures });
+                    continue;
+                }
             }
 
             // Delete the keg directory tree.
             fs.deleteTreeAbsolute(keg_path) catch |del_err| {
                 err_out.err("Could not remove {s}/{s}: {s}", .{ name, version, @errorName(del_err) });
+                artifact_failures += 1;
             };
         }
 
@@ -116,7 +139,14 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
             }
         }
 
-        // Print completion section.
+        // Only claim success when nothing was left behind; a half-removed
+        // cask reporting "is uninstalled" is how root-owned files get stranded.
+        if (artifact_failures > 0) {
+            err_out.err("{s} was not fully uninstalled.", .{name});
+            had_failure = true;
+            continue;
+        }
+
         const done_title = std.fmt.allocPrint(allocator, "{s} is uninstalled", .{name}) catch {
             err_out.err("Failed to format completion message for {s}.", .{name});
             continue;
@@ -132,17 +162,13 @@ pub fn uninstallCmd(allocator: Allocator, args: []const []const u8, config: Conf
             state.save() catch {};
         }
     }
+
+    if (had_failure) std.process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-test "uninstallCmd compiles and has correct signature" {
-    // Smoke test: verifies the function signature is correct and the module compiles.
-    const handler: @import("../dispatch.zig").CommandFn = uninstallCmd;
-    _ = handler;
-}
 
 test "parseUninstallArgs extracts single package name" {
     const args = &[_][]const u8{"wget"};

--- a/src/cmd/upgrade.zig
+++ b/src/cmd/upgrade.zig
@@ -753,9 +753,20 @@ fn runCaskUpgrade(
         };
         defer cask_mod.freeResolvedCask(allocator, resolved);
 
-        if (resolved.binaries.len == 0 and resolved.apps.len == 0) {
-            err_out.warn("Skipping cask \"{s}\": no binaries or app bundle.", .{item.token});
-            continue;
+        switch (cask_mod.installability(resolved)) {
+            .ok => {},
+            .no_artifacts => {
+                err_out.warn("Skipping cask \"{s}\": no binaries, app bundle, or package.", .{item.token});
+                continue;
+            },
+            // Without this, upgrade would be a way around the install gate:
+            // brew installs these, and bru scans the Caskroom regardless of
+            // who filled it.
+            .unremovable => {
+                err_out.warn("Skipping cask \"{s}\": uninstall needs steps bru doesn't support.", .{item.token});
+                err_out.print("Use: brew upgrade --cask {s}\n", .{item.token});
+                continue;
+            },
         }
 
         cask_install.installCask(allocator, config, &http_client, resolved, item.installed_version) catch |install_err| {

--- a/src/formula.zig
+++ b/src/formula.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const json_helpers = @import("json_helpers.zig");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
@@ -160,14 +161,14 @@ fn parseOneFormula(allocator: Allocator, obj: std.json.ObjectMap, platform_tags:
     const caveats = try allocator.dupe(u8, jsonStr(obj, "caveats") orelse "");
     errdefer allocator.free(caveats);
 
-    const dependencies = try parseStringArray(allocator, obj, "dependencies");
-    errdefer freeStringSlice(allocator, dependencies);
+    const dependencies = try json_helpers.parseStringArray(allocator, obj, "dependencies");
+    errdefer json_helpers.freeStringSlice(allocator, dependencies);
 
-    const build_dependencies = try parseStringArray(allocator, obj, "build_dependencies");
-    errdefer freeStringSlice(allocator, build_dependencies);
+    const build_dependencies = try json_helpers.parseStringArray(allocator, obj, "build_dependencies");
+    errdefer json_helpers.freeStringSlice(allocator, build_dependencies);
 
-    const oldnames = try parseStringArray(allocator, obj, "oldnames");
-    errdefer freeStringSlice(allocator, oldnames);
+    const oldnames = try json_helpers.parseStringArray(allocator, obj, "oldnames");
+    errdefer json_helpers.freeStringSlice(allocator, oldnames);
 
     const deprecation_replacement = try allocator.dupe(u8, jsonStr(obj, "deprecation_replacement_formula") orelse "");
     errdefer allocator.free(deprecation_replacement);
@@ -252,9 +253,9 @@ pub fn freeFormula(allocator: Allocator, f: FormulaInfo) void {
     allocator.free(f.version);
     allocator.free(f.tap);
     allocator.free(f.caveats);
-    freeStringSlice(allocator, f.dependencies);
-    freeStringSlice(allocator, f.build_dependencies);
-    freeStringSlice(allocator, f.oldnames);
+    json_helpers.freeStringSlice(allocator, f.dependencies);
+    json_helpers.freeStringSlice(allocator, f.build_dependencies);
+    json_helpers.freeStringSlice(allocator, f.oldnames);
     allocator.free(f.deprecation_replacement);
     allocator.free(f.bottle_root_url);
     allocator.free(f.bottle_sha256);
@@ -296,36 +297,6 @@ fn asObject(val: std.json.Value) ?std.json.ObjectMap {
     };
 }
 
-/// Parse a JSON array of strings into an owned slice.
-fn parseStringArray(allocator: Allocator, obj: std.json.ObjectMap, key: []const u8) ![]const []const u8 {
-    const arr_val = obj.get(key) orelse return try allocator.alloc([]const u8, 0);
-    const arr = switch (arr_val) {
-        .array => |a| a,
-        else => return try allocator.alloc([]const u8, 0),
-    };
-
-    var result = try std.ArrayList([]const u8).initCapacity(allocator, arr.items.len);
-    errdefer {
-        for (result.items) |s| allocator.free(s);
-        result.deinit(allocator);
-    }
-
-    for (arr.items) |item| {
-        const s = switch (item) {
-            .string => |s| s,
-            else => continue,
-        };
-        result.appendAssumeCapacity(try allocator.dupe(u8, s));
-    }
-
-    return try result.toOwnedSlice(allocator);
-}
-
-/// Free a slice of owned strings.
-fn freeStringSlice(allocator: Allocator, slice: []const []const u8) void {
-    for (slice) |s| allocator.free(s);
-    allocator.free(slice);
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/json_helpers.zig
+++ b/src/json_helpers.zig
@@ -25,6 +25,38 @@ pub fn writeJsonStr(writer: anytype, s: []const u8) !void {
     try writer.writeByte('"');
 }
 
+/// Parse a JSON array of strings into an owned slice; empty when the key is
+/// absent or not an array. Non-string elements are skipped.
+pub fn parseStringArray(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8) ![][]const u8 {
+    const arr_val = obj.get(key) orelse return try allocator.alloc([]const u8, 0);
+    const arr = switch (arr_val) {
+        .array => |a| a,
+        else => return try allocator.alloc([]const u8, 0),
+    };
+
+    var result = try std.ArrayList([]const u8).initCapacity(allocator, arr.items.len);
+    errdefer {
+        for (result.items) |s| allocator.free(s);
+        result.deinit(allocator);
+    }
+
+    for (arr.items) |item| {
+        const s = switch (item) {
+            .string => |v| v,
+            else => continue,
+        };
+        result.appendAssumeCapacity(try allocator.dupe(u8, s));
+    }
+
+    return try result.toOwnedSlice(allocator);
+}
+
+/// Free a slice of owned strings.
+pub fn freeStringSlice(allocator: std.mem.Allocator, slice: []const []const u8) void {
+    for (slice) |s| allocator.free(s);
+    allocator.free(slice);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

- `bru install --cask <any pkg cask>` fails with `UnsupportedArchiveType`. A `pkg` is not an archive — brew hands it to `/usr/sbin/installer -target /` as root — so there was nothing to extract. 658 of 7,701 casks are affected.
- A pkg writes **outside** the Caskroom (`/usr/local`, `/Library`, `/var/db/receipts`). Deleting the version dir does not undo it, so installing one without recording how to remove it strands root-owned files permanently.
- `binary` artifacts in pkg casks use absolute sources (`/usr/local/sessionmanagerplugin/bin/…`). Joining those to a root yields `{root}//usr/local/…`, which never resolves.

## Objectives

1. Install pkg casks via `installer`, and only those bru can also uninstall.
2. Record an undo plan at install time and execute it on uninstall.
3. Keep install and upgrade on one gate so upgrade is not a way around it.
4. Leave app/binary cask behavior unchanged.

<details>
<summary><b>Assumptions</b></summary>

- `installer` requires root: payload targets and `/var/db/receipts` are `root:wheel`. brew passes `sudo: true` here too.
- The `uninstall` stanza is the only description of how to remove a pkg. If bru cannot perform it in full, brew must own the whole install — the same deferral bru made before pkg support existed.
- A cask's `pkg` artifact is authoritative for the staged filename; the URL is not (11 casks disagree, 7 only by `%20`).
- `rmdir` refusing non-empty dirs is what keeps shared parents (`/usr/local`) intact; the denylist makes that explicit rather than incidental.
- A pkgutil value may be a Ruby Regexp. bru cannot evaluate one, and a mis-expansion would forget another package's receipt, so it counts as unsupported.
</details>

<details>
<summary><b>Changes</b></summary>

- `(1,3)` `src/cask.zig` — parse `pkg` artifacts and the `uninstall` stanza into `UninstallPlan`; unimplemented directives are named in `unsupported`. New `installability()` predicate. Tests: real session-manager-plugin and adguard shapes, string-vs-array values, regex rejection, gate matrix.
- `(1,3)` `src/cmd/install.zig`, `src/cmd/upgrade.zig` — both switch on `installability()`. Install execs brew; upgrade skips with a hint.
- `(1)` `src/cask_install.zig` — stage the pkg under its declared name, run `installer` under sudo with inherited stdio, resolve absolute `binary` sources. `installCask` itself returns `CaskNotRemovable` so the invariant does not depend on callers.
- `(2)` `src/cask_install.zig`, `src/cmd/uninstall.zig` — write `.bru-uninstall.json`; on uninstall run pkgutil → delete → trash → rmdir, returning a failure count. The keg is kept and the exit code is non-zero when anything is left behind. Tests: JSON round-trip with spaces/tildes, `~`/`$HOME` expansion, delete/rmdir semantics, system-path guard, removal ordering, batching, keg ownership, unreadable plan, and an end-to-end run of the directive composition.
- `(4)` Plan recording is scoped to `pkgs.len > 0`.
- `src/json_helpers.zig`, `src/formula.zig` — `parseStringArray`/`freeStringSlice` were duplicated; moved to the shared module.
</details>

<details>
<summary><b>Notes</b></summary>

- **Security (found in review):** `pkgutil` was invoked by PATH lookup at three sites, and its output builds the argv for a root `rm`. Nine user-writable directories precede `/usr/sbin` in a normal PATH, so a planted `pkgutil` could delete arbitrary files as root. Absolute path everywhere now.
- **Every runtime failure of the undo mechanism was suppressed** — the plan could fail to be written, fail to be read, or be applied partially, and in each case the user saw `is uninstalled` and exit 0 while root-owned files remained. Now: plan-write failure aborts before `installer` runs; an unreadable plan refuses the uninstall rather than reading as "nothing to undo"; the receipt is forgotten only after its files are gone, so a failed removal keeps the manifest that enumerates them.
- `bru uninstall` on a **brew-installed** cask now defers to brew instead of deleting the keg. Deleting it destroyed the entry brew needs, leaving the payload removable by neither tool. This applies to all cask types, not just pkg.
- **269 of 658 pkg casks install; 389 defer to brew.** Deferring is the pre-existing behavior for these, not a regression — 638 previously hit "no installable artifacts."
- The gate lives in `installCask`, not only at call sites. Upgrade originally lacked it, which made 389 casks reachable as root with no undo record.
- **A partial plan is never recorded.** Running `delete:` without the `launchctl:` that precedes it strips a loaded daemon's files while launchd still references them — worse than doing nothing. App casks therefore keep their prior behavior rather than gaining half a teardown.
- Removal runs as root, so paths are `realpath`'d before the system-directory check; a plain string compare lets `/usr/local/..` or a symlinked parent through.
- `sudo` is only escalated to on permission failure, so uninstalling a cask that owns nothing outside `$HOME` never prompts.
- Not addressed: upgrade does not run the *old* version's plan. bru installs the new version before removing the old dir, so replaying the old plan would delete the payload just written. Correct ordering (uninstall-then-install, as brew does) is a larger restructure.
- Verified: 337 tests pass. End-to-end against the live API — `adguard` defers, `session-manager-plugin` reaches `installer`, `bru upgrade` skips gated casks, and a synthetic caskroom entry exercised delete/rmdir/trash (rmdir correctly refused an occupied dir). The privileged `installer` run itself needs an interactive sudo password and is unverified.
</details>
